### PR TITLE
Read liberty version from xml settings

### DIFF
--- a/lemminx-liberty/src/main/java/io/openliberty/lemminx/liberty/LibertyCompletionParticipant.java
+++ b/lemminx-liberty/src/main/java/io/openliberty/lemminx/liberty/LibertyCompletionParticipant.java
@@ -8,6 +8,7 @@ import org.eclipse.lsp4j.CompletionItem;
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
 import io.openliberty.lemminx.liberty.models.feature.*;
 import io.openliberty.lemminx.liberty.services.FeatureService;
+import io.openliberty.lemminx.liberty.services.SettingsService;
 import io.openliberty.lemminx.liberty.util.*;
 
 import java.io.IOException;
@@ -40,7 +41,8 @@ public class LibertyCompletionParticipant extends CompletionParticipantAdapter {
     }
 
     private void listFeatures(ICompletionResponse response) throws IOException {
-        List<Feature> features = FeatureService.getInstance().getFeatures("20.0.0.8");
+        final String libertyVersion = SettingsService.getInstance().getLibertyVersion();
+        List<Feature> features = FeatureService.getInstance().getFeatures(libertyVersion);
         for (Feature feature : features) {
             CompletionItem item = new CompletionItem();
             item.setLabel(feature.getWlpInformation().getShortName());

--- a/lemminx-liberty/src/main/java/io/openliberty/lemminx/liberty/LibertyDiagnosticParticipant.java
+++ b/lemminx-liberty/src/main/java/io/openliberty/lemminx/liberty/LibertyDiagnosticParticipant.java
@@ -10,6 +10,7 @@ import org.eclipse.lsp4j.jsonrpc.CancelChecker;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 import io.openliberty.lemminx.liberty.services.FeatureService;
+import io.openliberty.lemminx.liberty.services.SettingsService;
 import io.openliberty.lemminx.liberty.util.*;
 import java.io.IOException;
 import java.util.*;
@@ -45,6 +46,8 @@ public class LibertyDiagnosticParticipant implements IDiagnosticsParticipant {
             return;
         }
 
+        final String libertyVersion = SettingsService.getInstance().getLibertyVersion();
+
         // Search for duplicate features
         // or features that do not exist
         Set<String> includedFeatures = new HashSet<>();
@@ -53,7 +56,7 @@ public class LibertyDiagnosticParticipant implements IDiagnosticsParticipant {
             DOMNode featureNode = (DOMNode) features.item(i);
             DOMNode featureTextNode = (DOMNode) featureNode.getChildNodes().item(0);
             String featureName = featureTextNode.getTextContent();
-            if (!FeatureService.getInstance().featureExists(featureName, "20.0.0.8")) {
+            if (!FeatureService.getInstance().featureExists(featureName, libertyVersion)) {
                 Range range = XMLPositionUtility.createRange(featureTextNode.getStart(), featureTextNode.getEnd(),
                         domDocument);
                 String message = "ERROR: The " + featureName + " feature does not exist.";

--- a/lemminx-liberty/src/main/java/io/openliberty/lemminx/liberty/LibertyExtension.java
+++ b/lemminx-liberty/src/main/java/io/openliberty/lemminx/liberty/LibertyExtension.java
@@ -6,10 +6,17 @@ import org.eclipse.lemminx.services.extensions.IXMLExtension;
 import org.eclipse.lemminx.services.extensions.XMLExtensionsRegistry;
 import org.eclipse.lemminx.services.extensions.diagnostics.IDiagnosticsParticipant;
 import org.eclipse.lemminx.services.extensions.save.ISaveContext;
+import org.eclipse.lemminx.services.extensions.save.ISaveContext.SaveContextType;
 import org.eclipse.lemminx.uriresolver.URIResolverExtension;
 import org.eclipse.lsp4j.InitializeParams;
 
+import java.util.logging.Logger;
+
+import io.openliberty.lemminx.liberty.services.SettingsService;
+
 public class LibertyExtension implements IXMLExtension {
+
+    private static final Logger LOGGER = Logger.getLogger(LibertyExtension.class.getName());
 
     private URIResolverExtension xsdResolver;
     private ICompletionParticipant completionParticipant;
@@ -39,8 +46,16 @@ public class LibertyExtension implements IXMLExtension {
         xmlExtensionsRegistry.unregisterDiagnosticsParticipant(diagnosticsParticipant);
     }
 
+    // Do save is called on startup with a Settings update
+    // and any time the settings are updated.
     @Override
-    public void doSave(ISaveContext iSaveContext) {
-        // TODO: 
+    public void doSave(ISaveContext saveContext) {
+        // Only need to update settings if the save event was for settings
+        // Not if an xml file was updated.
+        if (saveContext.getType() == SaveContextType.SETTINGS) {
+            Object xmlSettings = saveContext.getSettings();
+            SettingsService.getInstance().updateLibertySettings(xmlSettings);
+            LOGGER.fine("Liberty XML settings updated");
+        }
     }
 }

--- a/lemminx-liberty/src/main/java/io/openliberty/lemminx/liberty/LibertyHoverParticipant.java
+++ b/lemminx-liberty/src/main/java/io/openliberty/lemminx/liberty/LibertyHoverParticipant.java
@@ -7,6 +7,7 @@ import org.eclipse.lsp4j.Hover;
 import org.eclipse.lsp4j.MarkupContent;
 import io.openliberty.lemminx.liberty.models.feature.*;
 import io.openliberty.lemminx.liberty.services.FeatureService;
+import io.openliberty.lemminx.liberty.services.SettingsService;
 import io.openliberty.lemminx.liberty.util.*;
 
 import java.io.IOException;
@@ -42,7 +43,7 @@ public class LibertyHoverParticipant implements IHoverParticipant {
 		if (parentElement.getTagName().equals(LibertyConstants.FEATURE_ELEMENT)) {
 			try {
 				String featureName = request.getNode().getTextContent();
-				return getHoverFeatureDescription(featureName, "20.0.0.8");
+				return getHoverFeatureDescription(featureName);
 			} catch (IOException e) {
 				System.err.println("Error getting features");
 				System.err.println(e.getMessage());
@@ -52,7 +53,8 @@ public class LibertyHoverParticipant implements IHoverParticipant {
 		return null;
 	}
 
-	private Hover getHoverFeatureDescription(String featureName, String libertyVersion) throws IOException {
+	private Hover getHoverFeatureDescription(String featureName) throws IOException {
+		final String libertyVersion = SettingsService.getInstance().getLibertyVersion();
 		Optional<Feature> feature = FeatureService.getInstance().getFeature(featureName, libertyVersion);
 		if (feature.isPresent()) {
 			return new Hover(new MarkupContent("plaintext", feature.get().getShortDescription()));

--- a/lemminx-liberty/src/main/java/io/openliberty/lemminx/liberty/models/settings/AllSettings.java
+++ b/lemminx-liberty/src/main/java/io/openliberty/lemminx/liberty/models/settings/AllSettings.java
@@ -1,0 +1,21 @@
+package io.openliberty.lemminx.liberty.models.settings;
+
+import com.google.gson.annotations.JsonAdapter;
+import org.eclipse.lsp4j.jsonrpc.json.adapters.JsonElementTypeAdapter;
+
+/**
+ * Model for top level xml settings JSON object.
+ */
+public class AllSettings {
+  @JsonAdapter(JsonElementTypeAdapter.Factory.class)
+  private Object liberty;
+
+  public Object getLiberty() {
+    return liberty;
+  }
+
+  public void setLiberty(Object liberty) {
+    this.liberty = liberty;
+  }
+
+}

--- a/lemminx-liberty/src/main/java/io/openliberty/lemminx/liberty/models/settings/LibertySettings.java
+++ b/lemminx-liberty/src/main/java/io/openliberty/lemminx/liberty/models/settings/LibertySettings.java
@@ -1,0 +1,19 @@
+package io.openliberty.lemminx.liberty.models.settings;
+
+/**
+ * Model for settings under the 'liberty' key in xml settings
+ * Ie. version refers to: xml.liberty.version
+ */
+public class LibertySettings {
+
+  private String version;
+
+  public String getVersion() {
+    return version;
+  }
+
+  public void setVersion(String version) {
+    this.version = version;
+  }
+
+}

--- a/lemminx-liberty/src/main/java/io/openliberty/lemminx/liberty/services/FeatureService.java
+++ b/lemminx-liberty/src/main/java/io/openliberty/lemminx/liberty/services/FeatureService.java
@@ -14,8 +14,12 @@ import io.openliberty.lemminx.liberty.models.feature.*;
 import io.openliberty.lemminx.liberty.util.LibertyConstants;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import java.util.logging.Logger;
+
 
 public class FeatureService {
+
+  private static final Logger LOGGER = Logger.getLogger(FeatureService.class.getName());
 
   // Singleton so that only 1 Feature Service can be initialized and is
   // shared between all Lemminx Language Feature Participants
@@ -59,6 +63,7 @@ public class FeatureService {
   }
 
   public List<Feature> getFeatures(String libertyVersion) throws IOException {
+    LOGGER.fine("Getting features for version: " + libertyVersion);
     // if the features are already cached in the feature cache
     if (featureCache.containsKey(libertyVersion)) {
       return featureCache.get(libertyVersion);

--- a/lemminx-liberty/src/main/java/io/openliberty/lemminx/liberty/services/SettingsService.java
+++ b/lemminx-liberty/src/main/java/io/openliberty/lemminx/liberty/services/SettingsService.java
@@ -1,0 +1,45 @@
+package io.openliberty.lemminx.liberty.services;
+
+import org.eclipse.lemminx.utils.JSONUtility;
+import io.openliberty.lemminx.liberty.models.settings.*;
+
+public class SettingsService {
+
+  // Singleton so that only 1 Settings Service can be initialized and is
+  // shared between all Lemminx Language Feature Participants
+
+  private static SettingsService instance = new SettingsService();
+
+  public static SettingsService getInstance() {
+    return instance;
+  }
+
+  private static String DEFAULT_SERVER_VERSION = "20.0.0.9";
+
+  private SettingsService() {
+  }
+
+  private LibertySettings settings;
+
+  /**
+   * Takes the xml settings object and parses out the Liberty Settings
+   * @param xmlSettings - All xml settings provided by the client
+   */
+  public void updateLibertySettings(Object xmlSettings) {
+    AllSettings rootSettings = JSONUtility.toModel(xmlSettings, AllSettings.class);
+    if (rootSettings != null) {
+      settings = JSONUtility.toModel(rootSettings.getLiberty(), LibertySettings.class);
+    }
+  }
+
+  public String getLibertyVersion() {
+    if (settings != null) {
+      String version = settings.getVersion();
+      if (version != null) {
+        return version;
+      }
+    }
+
+    return DEFAULT_SERVER_VERSION;
+  }
+}


### PR DESCRIPTION
Allows users to specify a version of liberty to use for getting a feature list with the setting `xml.liberty.version`.