### PR TITLE
fix diagnostic comment error and add diagnostic tests

### DIFF
--- a/lemminx-liberty/src/main/java/io/openliberty/lemminx/liberty/LibertyCompletionParticipant.java
+++ b/lemminx-liberty/src/main/java/io/openliberty/lemminx/liberty/LibertyCompletionParticipant.java
@@ -48,7 +48,7 @@ public class LibertyCompletionParticipant extends CompletionParticipantAdapter {
         // Build a text edit to replace whatever is inside <feature></feature>
         // with the completion result
         Range range = XMLPositionUtility.createRange(featureElement.getStartTagCloseOffset() + 1,
-                featureElement.getEndTagCloseOffset(), document);
+                featureElement.getEndTagOpenOffset(), document);
         TextEdit edit = new TextEdit(range, featureName);
 
         // Build the completion item to return to the client

--- a/lemminx-liberty/src/test/java/io/openliberty/LibertyDiagnosticTest.java
+++ b/lemminx-liberty/src/test/java/io/openliberty/LibertyDiagnosticTest.java
@@ -1,0 +1,63 @@
+package io.openliberty;
+
+import org.eclipse.lemminx.XMLAssert;
+import org.eclipse.lsp4j.Diagnostic;
+import org.junit.jupiter.api.Test;
+
+import static org.eclipse.lemminx.XMLAssert.r;
+
+public class LibertyDiagnosticTest {
+
+    static String newLine = System.lineSeparator();
+    static String serverXMLURI = "test/server.xml";
+
+    @Test
+    public void testFeatureDuplicateDiagnostic() {
+        String serverXML = String.join(newLine, //
+                "<server description=\"Sample Liberty server\">", //
+                "       <featureManager>", //
+                "               <feature>jaxrs-2.1</feature>", //
+                "               <feature>jaxrs-2.1</feature>", //
+                "               <feature>jsonp-1.1</feature>", //
+                "               <!-- <feature>comment</feature> -->", //
+                "               <feature>jsonp-1.1</feature>", //
+                "       </featureManager>", //
+                "</server>" //
+        );
+
+        Diagnostic dup1 = new Diagnostic();
+        dup1.setRange(r(3, 24, 3, 33));
+        dup1.setMessage("ERROR: jaxrs-2.1 is already included.");
+
+        Diagnostic dup2 = new Diagnostic();
+        dup2.setRange(r(6, 24, 6, 33));
+        dup2.setMessage("ERROR: jsonp-1.1 is already included.");
+
+        XMLAssert.testDiagnosticsFor(serverXML, null, null, serverXMLURI, dup1, dup2);
+    }
+
+    @Test
+    public void testInvalidFeatureDiagnostic() {
+        String serverXML = String.join(newLine, //
+                "<server description=\"Sample Liberty server\">", //
+                "       <featureManager>", //
+                "               <feature>jaxrs-2.1</feature>", //
+                "               <feature>jax</feature>", //
+                "               <feature>jsonp-1.1</feature>", //
+                "               <!-- <feature>comment</feature> -->", //
+                "               <feature>invalid</feature>", //
+                "       </featureManager>", //
+                "</server>" //
+        );
+        Diagnostic invalid1 = new Diagnostic();
+        invalid1.setRange(r(3, 24, 3, 27));
+        invalid1.setMessage("ERROR: The feature \"jax\" does not exist.");
+
+        Diagnostic invalid2 = new Diagnostic();
+        invalid2.setRange(r(6, 24, 6, 31));
+        invalid2.setMessage("ERROR: The feature \"invalid\" does not exist.");
+
+        XMLAssert.testDiagnosticsFor(serverXML, null, null, serverXMLURI, invalid1, invalid2);
+    }
+
+}


### PR DESCRIPTION
Fixes #24 
- Ignores comments(child nodes that do not have a text value) when calculating feature diagnostics
- Integration tests for duplication features and invalid features

- use `featureElement.getEndTagOpenOffset()` so that `</feature>` closing tag is not replaced for TextEdits associated with CompletionItems

Signed-off-by: Kathryn Kodama <kathryn.s.kodama@gmail.com>