### PR TITLE
Test XSD hover availability

### DIFF
--- a/lemminx-liberty/src/main/java/io/openliberty/lemminx/liberty/LibertyXSDURIResolver.java
+++ b/lemminx-liberty/src/main/java/io/openliberty/lemminx/liberty/LibertyXSDURIResolver.java
@@ -26,8 +26,10 @@ public class LibertyXSDURIResolver implements URIResolverExtension, IExternalGra
    * server.xsd it takes the resource located at `/schema/server.xsd` and deploys
    * it to:
    * ~/.lemminx/cache/https/github.com/OpenLiberty/liberty-language-server/master/lemminx-liberty/src/main/resources/schema/server.xsd
+   * 
+   * Declared public to be used by tests
    */
-  private static final ResourceToDeploy SERVER_XSD_RESOURCE = new ResourceToDeploy(XSD_RESOURCE_URL,
+  public static final ResourceToDeploy SERVER_XSD_RESOURCE = new ResourceToDeploy(XSD_RESOURCE_URL,
       XSD_CLASSPATH_LOCATION);
 
   public String resolve(String baseLocation, String publicId, String systemId) {

--- a/lemminx-liberty/src/test/java/io/openliberty/LibertyCompletionTest.java
+++ b/lemminx-liberty/src/test/java/io/openliberty/LibertyCompletionTest.java
@@ -3,7 +3,6 @@ package io.openliberty;
 import org.eclipse.lemminx.XMLAssert;
 import org.eclipse.lemminx.commons.BadLocationException;
 import org.eclipse.lsp4j.CompletionItem;
-import org.eclipse.lsp4j.TextEdit;
 
 import static org.eclipse.lemminx.XMLAssert.*;
 
@@ -11,7 +10,7 @@ import org.junit.jupiter.api.Test;
 
 public class LibertyCompletionTest {
 
-        static String newLine = System.getProperty("line.separator");
+        static String newLine = System.lineSeparator();
         static String serverXMLURI = "test/server.xml";
 
         // Tests the availability of completion of XML elements provided by the

--- a/lemminx-liberty/src/test/java/io/openliberty/LibertyHoverTest.java
+++ b/lemminx-liberty/src/test/java/io/openliberty/LibertyHoverTest.java
@@ -1,15 +1,17 @@
 package io.openliberty;
 
 import org.junit.jupiter.api.Test;
+
+import static io.openliberty.lemminx.liberty.LibertyXSDURIResolver.SERVER_XSD_RESOURCE;;
+
 import org.eclipse.lemminx.XMLAssert;
 import org.eclipse.lemminx.commons.BadLocationException;
-
 import static org.eclipse.lemminx.XMLAssert.r;
-import org.eclipse.lemminx.services.XMLLanguageService;
+import java.io.IOException;
 
 public class LibertyHoverTest {
 
-        static String newLine = System.getProperty("line.separator");
+        static String newLine = System.lineSeparator();
         static String serverXMLURI = "test/server.xml";
 
         @Test
@@ -23,12 +25,30 @@ public class LibertyHoverTest {
                                 "</server>" //
                 );
 
-                XMLAssert.assertHover(serverXML, "test/server.xml",
+                XMLAssert.assertHover(serverXML, serverXMLURI,
                                 "This feature enables support for Java API for RESTful Web Services v2.1.  "
                                                 + "JAX-RS annotations can be used to define web service clients and endpoints that comply with the REST architectural style. "
                                                 + "Endpoints are accessed through a common interface that is based on the HTTP standard methods.",
                                 r(2, 24, 2, 33));
 
+        }
+
+        @Test
+        public void testXSDSchemaHover() throws BadLocationException, IOException {
+                String serverXSDURI = SERVER_XSD_RESOURCE.getDeployedPath().toUri().toString().replace("///", "/");
+
+                String serverXML = String.join(newLine, //
+                                "<server description=\"Sample Liberty server\">", //
+                                "       <feature|Manager>", //
+                                "               <feature>jaxrs-2.1</feature>", //
+                                "       </featureManager>", //
+                                "</server>" //
+                );
+
+                XMLAssert.assertHover(serverXML, serverXMLURI, "Defines how the server loads features." + //
+                                System.lineSeparator() + System.lineSeparator() + //
+                                "Source: [server.xsd](" + serverXSDURI + ")", //
+                                r(1, 8, 1, 22));
         }
 
 }


### PR DESCRIPTION
Adds a test that tests the availability of hover documentation provided by the server.xsd file.

Signed-off-by: Ryan Zegray <ryan.zegray@ibm.com>