### PR TITLE
Avoid showing feature not found diagnostics for usr features

### DIFF
--- a/lemminx-liberty/src/main/java/io/openliberty/lemminx/liberty/LibertyDiagnosticParticipant.java
+++ b/lemminx-liberty/src/main/java/io/openliberty/lemminx/liberty/LibertyDiagnosticParticipant.java
@@ -54,9 +54,11 @@ public class LibertyDiagnosticParticipant implements IDiagnosticsParticipant {
         for (DOMNode featureNode : features) {
             DOMNode featureTextNode = (DOMNode) featureNode.getChildNodes().item(0);
             // skip nodes that do not have any text value (ie. comments)
-            if (featureTextNode != null) {
+            if (featureTextNode != null && featureTextNode.getTextContent() != null) {
                 String featureName = featureTextNode.getTextContent();
-                if (!FeatureService.getInstance().featureExists(featureName, libertyVersion, requestDelay)) {
+                // if the feature is not a user defined feature and the feature does not exist in the list of
+                // supported features show a "Feature does not exist" diagnostic
+                if (!featureName.startsWith("usr:") && !FeatureService.getInstance().featureExists(featureName, libertyVersion, requestDelay)) {
                     Range range = XMLPositionUtility.createRange(featureTextNode.getStart(), featureTextNode.getEnd(),
                             domDocument);
                     String message = "ERROR: The feature \"" + featureName + "\" does not exist.";


### PR DESCRIPTION
PR makes it so the lemminx extension does not show a "feature does not exist" diagnostic for usr defined features.

![image](https://user-images.githubusercontent.com/16768710/103567781-6a448800-4e92-11eb-8c8d-5c12da426173.png)

Extension will still show a diagnostic if a usr feature is included more than once. 
![image](https://user-images.githubusercontent.com/16768710/103567820-7b8d9480-4e92-11eb-8057-eac51adb743e.png)
