### PR TITLE
Liberty version and installed features fallback

### DIFF
--- a/lemminx-liberty/pom.xml
+++ b/lemminx-liberty/pom.xml
@@ -39,6 +39,21 @@
   <url>http://maven.apache.org</url>
   <dependencies>
     <dependency>
+      <groupId>javax.xml</groupId>
+      <artifactId>jaxb-api</artifactId>
+      <version>2.1</version>
+    </dependency>
+    <dependency>
+      <groupId>javax.activation</groupId>
+      <artifactId>activation</artifactId>
+      <version>1.1</version>
+    </dependency>
+    <dependency>
+      <groupId>org.glassfish.jaxb</groupId>
+      <artifactId>jaxb-runtime</artifactId>
+      <version>2.3.3</version>
+    </dependency>
+    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
       <version>5.6.1</version>

--- a/lemminx-liberty/src/main/java/io/openliberty/lemminx/liberty/LibertyCompletionParticipant.java
+++ b/lemminx-liberty/src/main/java/io/openliberty/lemminx/liberty/LibertyCompletionParticipant.java
@@ -74,7 +74,7 @@ public class LibertyCompletionParticipant extends CompletionParticipantAdapter {
     private List<CompletionItem> buildCompletionItems(DOMElement featureElement, DOMDocument domDocument,
             List<String> existingFeatures) {
 
-        String libertyVersion = LibertyUtils.getVersion(domDocument);
+        String libertyVersion = SettingsService.getInstance().getLibertyVersion();
         if (libertyVersion == null) {
             // try to get version from installed Liberty
             libertyVersion = LibertyUtils.getVersion(domDocument);

--- a/lemminx-liberty/src/main/java/io/openliberty/lemminx/liberty/LibertyCompletionParticipant.java
+++ b/lemminx-liberty/src/main/java/io/openliberty/lemminx/liberty/LibertyCompletionParticipant.java
@@ -74,11 +74,7 @@ public class LibertyCompletionParticipant extends CompletionParticipantAdapter {
     private List<CompletionItem> buildCompletionItems(DOMElement featureElement, DOMDocument domDocument,
             List<String> existingFeatures) {
 
-        String libertyVersion = SettingsService.getInstance().getLibertyVersion();
-        if (libertyVersion == null) {
-            // try to get version from installed Liberty
-            libertyVersion = LibertyUtils.getVersion(domDocument);
-        }
+        String libertyVersion = LibertyUtils.getVersion(domDocument);
 
         final int requestDelay = SettingsService.getInstance().getRequestDelay();
         List<Feature> features = FeatureService.getInstance().getFeatures(libertyVersion, requestDelay, domDocument.getDocumentURI());

--- a/lemminx-liberty/src/main/java/io/openliberty/lemminx/liberty/LibertyDiagnosticParticipant.java
+++ b/lemminx-liberty/src/main/java/io/openliberty/lemminx/liberty/LibertyDiagnosticParticipant.java
@@ -44,7 +44,11 @@ public class LibertyDiagnosticParticipant implements IDiagnosticsParticipant {
             return;
         }
 
-        final String libertyVersion = SettingsService.getInstance().getLibertyVersion();
+        String libertyVersion = SettingsService.getInstance().getLibertyVersion();
+        if (libertyVersion == null) {
+            // try to get version from installed Liberty
+            libertyVersion = LibertyUtils.getVersion(domDocument);
+        }
         final int requestDelay = SettingsService.getInstance().getRequestDelay();
 
         // Search for duplicate features
@@ -58,7 +62,7 @@ public class LibertyDiagnosticParticipant implements IDiagnosticsParticipant {
                 String featureName = featureTextNode.getTextContent();
                 // if the feature is not a user defined feature and the feature does not exist in the list of
                 // supported features show a "Feature does not exist" diagnostic
-                if (!featureName.startsWith("usr:") && !FeatureService.getInstance().featureExists(featureName, libertyVersion, requestDelay)) {
+                if (!featureName.startsWith("usr:") && !FeatureService.getInstance().featureExists(featureName, libertyVersion, requestDelay, domDocument.getDocumentURI())) {
                     Range range = XMLPositionUtility.createRange(featureTextNode.getStart(), featureTextNode.getEnd(),
                             domDocument);
                     String message = "ERROR: The feature \"" + featureName + "\" does not exist.";

--- a/lemminx-liberty/src/main/java/io/openliberty/lemminx/liberty/LibertyDiagnosticParticipant.java
+++ b/lemminx-liberty/src/main/java/io/openliberty/lemminx/liberty/LibertyDiagnosticParticipant.java
@@ -44,11 +44,8 @@ public class LibertyDiagnosticParticipant implements IDiagnosticsParticipant {
             return;
         }
 
-        String libertyVersion = SettingsService.getInstance().getLibertyVersion();
-        if (libertyVersion == null) {
-            // try to get version from installed Liberty
-            libertyVersion = LibertyUtils.getVersion(domDocument);
-        }
+        String libertyVersion =  LibertyUtils.getVersion(domDocument);
+
         final int requestDelay = SettingsService.getInstance().getRequestDelay();
 
         // Search for duplicate features

--- a/lemminx-liberty/src/main/java/io/openliberty/lemminx/liberty/LibertyExtension.java
+++ b/lemminx-liberty/src/main/java/io/openliberty/lemminx/liberty/LibertyExtension.java
@@ -9,9 +9,12 @@ import org.eclipse.lemminx.services.extensions.save.ISaveContext;
 import org.eclipse.lemminx.services.extensions.save.ISaveContext.SaveContextType;
 import org.eclipse.lemminx.uriresolver.URIResolverExtension;
 import org.eclipse.lsp4j.InitializeParams;
+import org.eclipse.lsp4j.WorkspaceFolder;
 
+import java.util.List;
 import java.util.logging.Logger;
 
+import io.openliberty.lemminx.liberty.services.LibertyProjectsManager;
 import io.openliberty.lemminx.liberty.services.SettingsService;
 
 public class LibertyExtension implements IXMLExtension {
@@ -25,6 +28,10 @@ public class LibertyExtension implements IXMLExtension {
 
     @Override
     public void start(InitializeParams initializeParams, XMLExtensionsRegistry xmlExtensionsRegistry) {
+        List<WorkspaceFolder> folders = initializeParams.getWorkspaceFolders();
+        if (folders != null) {
+            LibertyProjectsManager.getInstance().setWorkspaceFolders(folders);
+        }
         xsdResolver = new LibertyXSDURIResolver();
         xmlExtensionsRegistry.getResolverExtensionManager().registerResolver(xsdResolver);
 
@@ -40,6 +47,9 @@ public class LibertyExtension implements IXMLExtension {
 
     @Override
     public void stop(XMLExtensionsRegistry xmlExtensionsRegistry) {
+        // clean up .libertyls folders
+        LibertyProjectsManager.getInstance().cleanUpTempDirs();
+
         xmlExtensionsRegistry.getResolverExtensionManager().unregisterResolver(xsdResolver);
         xmlExtensionsRegistry.unregisterCompletionParticipant(completionParticipant);
         xmlExtensionsRegistry.unregisterHoverParticipant(hoverParticipant);

--- a/lemminx-liberty/src/main/java/io/openliberty/lemminx/liberty/LibertyExtension.java
+++ b/lemminx-liberty/src/main/java/io/openliberty/lemminx/liberty/LibertyExtension.java
@@ -28,9 +28,13 @@ public class LibertyExtension implements IXMLExtension {
 
     @Override
     public void start(InitializeParams initializeParams, XMLExtensionsRegistry xmlExtensionsRegistry) {
-        List<WorkspaceFolder> folders = initializeParams.getWorkspaceFolders();
-        if (folders != null) {
-            LibertyProjectsManager.getInstance().setWorkspaceFolders(folders);
+        try {
+            List<WorkspaceFolder> folders = initializeParams.getWorkspaceFolders();
+            if (folders != null) {
+                LibertyProjectsManager.getInstance().setWorkspaceFolders(folders);
+            }
+        } catch (NullPointerException e) {
+            LOGGER.warning("Could not get workspace folders: " + e.toString());
         }
         xsdResolver = new LibertyXSDURIResolver();
         xmlExtensionsRegistry.getResolverExtensionManager().registerResolver(xsdResolver);

--- a/lemminx-liberty/src/main/java/io/openliberty/lemminx/liberty/LibertyHoverParticipant.java
+++ b/lemminx-liberty/src/main/java/io/openliberty/lemminx/liberty/LibertyHoverParticipant.java
@@ -1,5 +1,6 @@
 package io.openliberty.lemminx.liberty;
 
+import org.eclipse.lemminx.dom.DOMDocument;
 import org.eclipse.lemminx.dom.DOMElement;
 import org.eclipse.lemminx.services.extensions.IHoverParticipant;
 import org.eclipse.lemminx.services.extensions.IHoverRequest;
@@ -41,16 +42,20 @@ public class LibertyHoverParticipant implements IHoverParticipant {
 		// if we are hovering over text inside a <feature> element
 		if (LibertyConstants.FEATURE_ELEMENT.equals(parentElement.getTagName())) {
 			String featureName = request.getNode().getTextContent();
-			return getHoverFeatureDescription(featureName);
+			return getHoverFeatureDescription(featureName, request.getXMLDocument());
 		}
 
 		return null;
 	}
 
-	private Hover getHoverFeatureDescription(String featureName) {
-		final String libertyVersion = SettingsService.getInstance().getLibertyVersion();
+	private Hover getHoverFeatureDescription(String featureName, DOMDocument domDocument) {
+		String libertyVersion = SettingsService.getInstance().getLibertyVersion();
+		if (libertyVersion == null) {
+            // try to get version from installed Liberty
+            libertyVersion = LibertyUtils.getVersion(domDocument);
+        }
 		final int requestDelay = SettingsService.getInstance().getRequestDelay();
-		Optional<Feature> feature = FeatureService.getInstance().getFeature(featureName, libertyVersion, requestDelay);
+		Optional<Feature> feature = FeatureService.getInstance().getFeature(featureName, libertyVersion, requestDelay, domDocument.getDocumentURI());
 		if (feature.isPresent()) {
 			return new Hover(new MarkupContent("plaintext", feature.get().getShortDescription()));
 		}

--- a/lemminx-liberty/src/main/java/io/openliberty/lemminx/liberty/LibertyHoverParticipant.java
+++ b/lemminx-liberty/src/main/java/io/openliberty/lemminx/liberty/LibertyHoverParticipant.java
@@ -49,11 +49,8 @@ public class LibertyHoverParticipant implements IHoverParticipant {
 	}
 
 	private Hover getHoverFeatureDescription(String featureName, DOMDocument domDocument) {
-		String libertyVersion = SettingsService.getInstance().getLibertyVersion();
-		if (libertyVersion == null) {
-            // try to get version from installed Liberty
-            libertyVersion = LibertyUtils.getVersion(domDocument);
-        }
+		String libertyVersion = LibertyUtils.getVersion(domDocument);
+
 		final int requestDelay = SettingsService.getInstance().getRequestDelay();
 		Optional<Feature> feature = FeatureService.getInstance().getFeature(featureName, libertyVersion, requestDelay, domDocument.getDocumentURI());
 		if (feature.isPresent()) {

--- a/lemminx-liberty/src/main/java/io/openliberty/lemminx/liberty/models/feature/Feature.java
+++ b/lemminx-liberty/src/main/java/io/openliberty/lemminx/liberty/models/feature/Feature.java
@@ -1,85 +1,91 @@
 package io.openliberty.lemminx.liberty.models.feature;
 
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlRootElement;
+
+@XmlRootElement(name = "feature")
+@XmlAccessorType(XmlAccessType.FIELD)
 public class Feature {
+
   private String description;
   private String licenseId;
   private String licenseType;
+
+  @XmlAttribute
   private String name;
   private String shortDescription;
+
   private String type;
   private String version;
   WlpInformation wlpInformation;
- 
- 
-  // Getter Methods 
- 
-  public String getDescription() {
-   return description;
-  }
- 
-  public String getLicenseId() {
-   return licenseId;
-  }
- 
-  public String getLicenseType() {
-   return licenseType;
-  }
- 
-  public String getName() {
-   return name;
-  }
- 
-  public String getShortDescription() {
-   return shortDescription;
-  }
- 
-  public String getType() {
-   return type;
-  }
- 
-  public String getVersion() {
-   return version;
-  }
- 
-  public WlpInformation getWlpInformation() {
-   return wlpInformation;
-  }
- 
-  // Setter Methods 
- 
-  public void setDescription(String description) {
-   this.description = description;
-  }
- 
-  public void setLicenseId(String licenseId) {
-   this.licenseId = licenseId;
-  }
- 
-  public void setLicenseType(String licenseType) {
-   this.licenseType = licenseType;
-  }
- 
-  public void setName(String name) {
-   this.name = name;
-  }
- 
-  public void setShortDescription(String shortDescription) {
-   this.shortDescription = shortDescription;
-  }
- 
-  public void setType(String type) {
-   this.type = type;
-  }
- 
-  public void setVersion(String version) {
-   this.version = version;
-  }
- 
-  public void setWlpInformation(WlpInformation wlpInformation) {
-   this.wlpInformation = wlpInformation;
-  }
- }
- 
- 
- 
 
+  // Getter Methods
+
+  public String getDescription() {
+    return description;
+  }
+
+  public String getLicenseId() {
+    return licenseId;
+  }
+
+  public String getLicenseType() {
+    return licenseType;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public String getShortDescription() {
+    return shortDescription;
+  }
+
+  public String getType() {
+    return type;
+  }
+
+  public String getVersion() {
+    return version;
+  }
+
+  public WlpInformation getWlpInformation() {
+    return wlpInformation;
+  }
+
+  // Setter Methods
+
+  public void setDescription(String description) {
+    this.description = description;
+  }
+
+  public void setLicenseId(String licenseId) {
+    this.licenseId = licenseId;
+  }
+
+  public void setLicenseType(String licenseType) {
+    this.licenseType = licenseType;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public void setShortDescription(String shortDescription) {
+    this.shortDescription = shortDescription;
+  }
+
+  public void setType(String type) {
+    this.type = type;
+  }
+
+  public void setVersion(String version) {
+    this.version = version;
+  }
+
+  public void setWlpInformation(WlpInformation wlpInformation) {
+    this.wlpInformation = wlpInformation;
+  }
+}

--- a/lemminx-liberty/src/main/java/io/openliberty/lemminx/liberty/models/feature/FeatureInfo.java
+++ b/lemminx-liberty/src/main/java/io/openliberty/lemminx/liberty/models/feature/FeatureInfo.java
@@ -1,0 +1,24 @@
+package io.openliberty.lemminx.liberty.models.feature;
+
+import java.util.List;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+
+@XmlRootElement(name = "featureInfo")
+@XmlAccessorType(XmlAccessType.FIELD)
+public class FeatureInfo {
+
+    @XmlElement(name = "feature")
+    private List<Feature> features = null;
+
+    public List<Feature> getFeatures() {
+        return features;
+    }
+
+    public void setFeatures(List<Feature> features) {
+        this.features = features;
+    }
+}

--- a/lemminx-liberty/src/main/java/io/openliberty/lemminx/liberty/models/feature/WlpInformation.java
+++ b/lemminx-liberty/src/main/java/io/openliberty/lemminx/liberty/models/feature/WlpInformation.java
@@ -20,6 +20,10 @@ public class WlpInformation {
 
   // Getter Methods
 
+  public WlpInformation(String shortName) {
+    this.shortName = shortName;
+  }
+
   public String getAppliesTo() {
     return appliesTo;
   }

--- a/lemminx-liberty/src/main/java/io/openliberty/lemminx/liberty/models/feature/WlpInformation.java
+++ b/lemminx-liberty/src/main/java/io/openliberty/lemminx/liberty/models/feature/WlpInformation.java
@@ -18,8 +18,6 @@ public class WlpInformation {
   private String mavenCoordinates;
   private String shortName;
 
-  // Getter Methods
-
   public WlpInformation(String shortName) {
     this.shortName = shortName;
   }
@@ -79,8 +77,6 @@ public class WlpInformation {
   public String getShortName() {
     return shortName;
   }
-
-  // Setter Methods
 
   public void setAppliesTo(String appliesTo) {
     this.appliesTo = appliesTo;

--- a/lemminx-liberty/src/main/java/io/openliberty/lemminx/liberty/services/FeatureService.java
+++ b/lemminx-liberty/src/main/java/io/openliberty/lemminx/liberty/services/FeatureService.java
@@ -1,22 +1,36 @@
 package io.openliberty.lemminx.liberty.services;
 
-import java.util.List;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
+import java.io.BufferedReader;
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.nio.charset.StandardCharsets;
+import java.net.URI;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-
-import io.openliberty.lemminx.liberty.models.feature.*;
-import io.openliberty.lemminx.liberty.util.LibertyConstants;
-import com.google.gson.Gson;
 import java.util.logging.Logger;
+
+import javax.xml.bind.JAXBContext;
+import javax.xml.bind.JAXBException;
+import javax.xml.bind.Unmarshaller;
+
+import com.google.gson.Gson;
 import com.google.gson.JsonParseException;
+
+import org.eclipse.lsp4j.WorkspaceFolder;
+
+import io.openliberty.lemminx.liberty.models.feature.Feature;
+import io.openliberty.lemminx.liberty.models.feature.FeatureInfo;
+import io.openliberty.lemminx.liberty.models.feature.WlpInformation;
+import io.openliberty.lemminx.liberty.util.LibertyConstants;
+import io.openliberty.lemminx.liberty.util.LibertyUtils;
 
 public class FeatureService {
 
@@ -59,6 +73,7 @@ public class FeatureService {
     // Only need the public features
     ArrayList<Feature> publicFeatures = readPublicFeatures(reader);
 
+    LOGGER.info("returning public features: " + publicFeatures.size());
     return publicFeatures;
   }
 
@@ -96,23 +111,24 @@ public class FeatureService {
 
     ArrayList<Feature> publicFeatures = new ArrayList<>();
     Arrays.asList(featureList).stream()
-            .filter(f -> f.getWlpInformation().getVisibility().equals(LibertyConstants.PUBLIC_VISIBILITY))
-            .forEach(publicFeatures::add);
+        .filter(f -> f.getWlpInformation().getVisibility().equals(LibertyConstants.PUBLIC_VISIBILITY))
+        .forEach(publicFeatures::add);
     defaultFeatureList = publicFeatures;
     return publicFeatures;
   }
 
-  public List<Feature> getFeatures(String libertyVersion, int requestDelay) {
+  public List<Feature> getFeatures(String libertyVersion, int requestDelay, String documentURI) {
     LOGGER.fine("Getting features for version: " + libertyVersion);
     // if the features are already cached in the feature cache
     if (featureCache.containsKey(libertyVersion)) {
       return featureCache.get(libertyVersion);
     }
+
     // else need to fetch the features from maven central
     try {
       // verify that request delay (seconds) has gone by since last fetch request
       long currentTime = System.currentTimeMillis();
-      if (this.featureUpdateTime == -1 || currentTime >= (this.featureUpdateTime + (requestDelay*1000))) {
+      if (this.featureUpdateTime == -1 || currentTime >= (this.featureUpdateTime + (requestDelay * 1000))) {
         List<Feature> features = fetchFeaturesForVersion(libertyVersion);
         featureCache.put(libertyVersion, features);
         this.featureUpdateTime = System.currentTimeMillis();
@@ -121,18 +137,75 @@ public class FeatureService {
     } catch (Exception e) {
       // do nothing, continue on to returning default feature list
     }
+
+    // if the installed features are already cached, return that list
+    if (featureCache.containsKey("installedFeatures")) {
+      return featureCache.get("installedFeatures");
+    }
+    // else need to fetch installed features from installed Liberty
+    // TODO: add logic to determine how often we should check for list of installed features
+    List<Feature> installedFeatures = getInstalledFeaturesList(documentURI);
+    if (installedFeatures.size() != 0) {
+      featureCache.put("installedFeatures", installedFeatures);
+      return installedFeatures;
+    }
+
     // return default feature list
     List<Feature> defaultFeatures = getDefaultFeatureList();
     return defaultFeatures;
   }
 
-  public Optional<Feature> getFeature(String featureName, String libertyVersion, int requestDelay) {
-    List<Feature> features = getFeatures(libertyVersion, requestDelay);
+  public Optional<Feature> getFeature(String featureName, String libertyVersion, int requestDelay, String documentURI) {
+    List<Feature> features = getFeatures(libertyVersion, requestDelay, documentURI);
     return features.stream().filter(f -> f.getWlpInformation().getShortName().equalsIgnoreCase(featureName))
         .findFirst();
   }
 
-  public boolean featureExists(String featureName, String libertyVersion, int requestDelay) {
-    return this.getFeature(featureName, libertyVersion, requestDelay).isPresent();
+  public boolean featureExists(String featureName, String libertyVersion, int requestDelay, String documentURI) {
+    return this.getFeature(featureName, libertyVersion, requestDelay, documentURI).isPresent();
   }
+
+  // get list of installed features from ws-featurelist.jar
+  private List<Feature> getInstalledFeaturesList(String documentURI) {
+    List<Feature> installedFeatures = new ArrayList<Feature>();
+    try {
+      String workspaceFolder = LibertyProjectsManager.getWorkspaceFolder(documentURI);
+      File tempDir = LibertyUtils.getTempDir(workspaceFolder);
+      Path featureListJAR = LibertyUtils.findFileInWorkspace(documentURI, "ws-featurelist.jar");
+
+      // TODO: verify where we should generate this temporary file
+      if (featureListJAR != null && featureListJAR.toFile().exists()) {
+        File tempFeaturesList = File.createTempFile("featureslist", ".xml", tempDir);
+        String[] cmd = { "java", "-jar", featureListJAR.toAbsolutePath().toString(),
+            tempFeaturesList.getAbsolutePath() };
+
+        Process proc = Runtime.getRuntime().exec(cmd);
+        BufferedReader in = new BufferedReader(new InputStreamReader(proc.getInputStream()));
+        String s = null;
+        while ((s = in.readLine()) != null) {
+          LOGGER.info(s);
+        }
+
+        JAXBContext jaxbContext = JAXBContext.newInstance(FeatureInfo.class);
+        Unmarshaller jaxbUnmarshaller = jaxbContext.createUnmarshaller();
+        FeatureInfo featureInfo = (FeatureInfo) jaxbUnmarshaller.unmarshal(tempFeaturesList);
+        if (featureInfo.getFeatures().size() > 0) {
+          for (int i = 0; i < featureInfo.getFeatures().size(); i++) {
+            Feature f = featureInfo.getFeatures().get(i);
+            f.setShortDescription(f.getDescription());
+            WlpInformation wlpInfo = new WlpInformation(f.getName());
+            f.setWlpInformation(wlpInfo);
+          }
+          installedFeatures = featureInfo.getFeatures();
+        }
+
+        tempFeaturesList.delete();
+      }
+    } catch (IOException | JAXBException e) {
+      LOGGER.warning("Unable to get installed features: " + e);
+    }
+
+    return installedFeatures;
+  }
+
 }

--- a/lemminx-liberty/src/main/java/io/openliberty/lemminx/liberty/services/FeatureService.java
+++ b/lemminx-liberty/src/main/java/io/openliberty/lemminx/liberty/services/FeatureService.java
@@ -167,7 +167,7 @@ public class FeatureService {
   private List<Feature> getInstalledFeaturesList(String documentURI) {
     List<Feature> installedFeatures = new ArrayList<Feature>();
     try {
-      LibertyWorkspace libertyWorkspace = LibertyProjectsManager.getWorkspaceFolder(documentURI);
+      LibertyWorkspace libertyWorkspace = LibertyProjectsManager.getInstance().getWorkspaceFolder(documentURI);
       if (libertyWorkspace == null || libertyWorkspace.getURI() == null) {
         return installedFeatures;
       }

--- a/lemminx-liberty/src/main/java/io/openliberty/lemminx/liberty/services/FeatureService.java
+++ b/lemminx-liberty/src/main/java/io/openliberty/lemminx/liberty/services/FeatureService.java
@@ -149,14 +149,9 @@ public class FeatureService {
       // do nothing, continue on to returning default feature list
     }
 
-    // if the installed features are already cached, return that list
-     if (featureCache.containsKey(LibertyConstants.INSTALLED_FEATURE_KEY)) {
-      return featureCache.get(LibertyConstants.INSTALLED_FEATURE_KEY);
-    }
-    // else need to fetch installed features from installed Liberty
+    // fetch installed features list
     List<Feature> installedFeatures = getInstalledFeaturesList(documentURI);
     if (installedFeatures.size() != 0) {
-      featureCache.put(LibertyConstants.INSTALLED_FEATURE_KEY, installedFeatures);
       return installedFeatures;
     }
 
@@ -177,15 +172,6 @@ public class FeatureService {
   }
 
   /**
-   * Remove a <version, feature list> pair from the feature cache
-   * 
-   * @param libertyVersion version key stored in the feature cache
-   */
-  public void removeFromFeatureCache(String libertyVersion) {
-    this.featureCache.remove(libertyVersion);
-  }
-
-  /**
    * Returns the list of installed features generated from ws-featurelist.jar.
    * Generated feature list is stored in the LemMinx cache. Returns an empty list
    * if cannot determine installed feature list.
@@ -200,6 +186,12 @@ public class FeatureService {
       if (libertyWorkspace == null || libertyWorkspace.getURI() == null) {
         return installedFeatures;
       }
+
+      // return installed features from cache
+      if (libertyWorkspace.getInstalledFeatureList().size() != 0) {
+        return libertyWorkspace.getInstalledFeatureList();
+      }
+
       Path featureListJAR = LibertyUtils.findFileInWorkspace(documentURI, "ws-featurelist.jar");
 
       if (featureListJAR != null && featureListJAR.toFile().exists()) {
@@ -231,6 +223,7 @@ public class FeatureService {
               f.setWlpInformation(wlpInfo);
             }
             installedFeatures = featureInfo.getFeatures();
+            libertyWorkspace.setInstalledFeatureList(installedFeatures);
           }
         } else {
           LOGGER.warning("Unable to load installed features into LemMinx cache, file does not exist:" + featureListCacheFile.toAbsolutePath());

--- a/lemminx-liberty/src/main/java/io/openliberty/lemminx/liberty/services/FeatureService.java
+++ b/lemminx-liberty/src/main/java/io/openliberty/lemminx/liberty/services/FeatureService.java
@@ -5,7 +5,6 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.net.URI;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
@@ -23,8 +22,6 @@ import javax.xml.bind.Unmarshaller;
 
 import com.google.gson.Gson;
 import com.google.gson.JsonParseException;
-
-import org.eclipse.lsp4j.WorkspaceFolder;
 
 import io.openliberty.lemminx.liberty.models.feature.Feature;
 import io.openliberty.lemminx.liberty.models.feature.FeatureInfo;
@@ -48,7 +45,7 @@ public class FeatureService {
     return instance;
   }
 
-  // Cache of liberty version -> list of supported features
+  // Cache of Liberty version -> list of supported features
   private Map<String, List<Feature>> featureCache;
   private List<Feature> defaultFeatureList;
   private long featureUpdateTime;
@@ -59,10 +56,10 @@ public class FeatureService {
   }
 
   /**
-   * Fetches information about liberty features from maven repo
+   * Fetches information about Liberty features from Maven repo
    *
-   * @param libertyVersion - version of liberty to fetch features for
-   * @return list of features supported by the provided version of liberty
+   * @param libertyVersion - version of Liberty to fetch features for
+   * @return list of features supported by the provided version of Liberty
    */
   private List<Feature> fetchFeaturesForVersion(String libertyVersion) throws IOException, JsonParseException {
     String featureEndpoint = String.format(
@@ -80,7 +77,7 @@ public class FeatureService {
   /**
    * Returns the default feature list
    *
-   * @return list of features supported by the default version of liberty
+   * @return list of features supported by the default version of Liberty
    */
   private List<Feature> getDefaultFeatureList() {
     try {
@@ -91,6 +88,7 @@ public class FeatureService {
         // Only need the public features
         defaultFeatureList = readPublicFeatures(reader);
       }
+      LOGGER.fine("Returning default feature list");
       return defaultFeatureList;
 
     } catch (JsonParseException e) {
@@ -151,7 +149,7 @@ public class FeatureService {
     }
 
     // return default feature list
-    List<Feature> defaultFeatures = getDefaultFeatureList();
+    List<Feature> defaultFeatures = getDefaultFeatureList(); 
     return defaultFeatures;
   }
 
@@ -169,11 +167,13 @@ public class FeatureService {
   private List<Feature> getInstalledFeaturesList(String documentURI) {
     List<Feature> installedFeatures = new ArrayList<Feature>();
     try {
-      String workspaceFolder = LibertyProjectsManager.getWorkspaceFolder(documentURI);
-      File tempDir = LibertyUtils.getTempDir(workspaceFolder);
+      LibertyWorkspace libertyWorkspace = LibertyProjectsManager.getWorkspaceFolder(documentURI);
+      if (libertyWorkspace == null || libertyWorkspace.getURI() == null) {
+        return installedFeatures;
+      }
+      File tempDir = LibertyUtils.getTempDir(libertyWorkspace.getURI());
       Path featureListJAR = LibertyUtils.findFileInWorkspace(documentURI, "ws-featurelist.jar");
 
-      // TODO: verify where we should generate this temporary file
       if (featureListJAR != null && featureListJAR.toFile().exists()) {
         File tempFeaturesList = File.createTempFile("featureslist", ".xml", tempDir);
         String[] cmd = { "java", "-jar", featureListJAR.toAbsolutePath().toString(),

--- a/lemminx-liberty/src/main/java/io/openliberty/lemminx/liberty/services/LibertyProjectsManager.java
+++ b/lemminx-liberty/src/main/java/io/openliberty/lemminx/liberty/services/LibertyProjectsManager.java
@@ -1,0 +1,91 @@
+package io.openliberty.lemminx.liberty.services;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.List;
+import java.util.logging.Logger;
+import java.util.stream.Collectors;
+
+import org.eclipse.lsp4j.WorkspaceFolder;
+
+public class LibertyProjectsManager {
+
+    private static final Logger LOGGER = Logger.getLogger(LibertyProjectsManager.class.getName());
+
+    private static final LibertyProjectsManager INSTANCE = new LibertyProjectsManager();
+
+    private List<WorkspaceFolder> workspaceFolders;
+    private static HashMap<String, String> libertyVersionCache;
+
+    public static LibertyProjectsManager getInstance() {
+        return INSTANCE;
+    }
+
+    private LibertyProjectsManager() {
+        libertyVersionCache = new HashMap<String, String>();
+    }
+
+    public void setWorkspaceFolders(List<WorkspaceFolder> workspaceFolders) {
+        this.workspaceFolders = workspaceFolders;
+    }
+
+    public List<WorkspaceFolder> getWorkspaceFolders() {
+        return this.workspaceFolders;
+    }
+
+    public void updateLibertyVersionCache(String workspaceFolderURI, String version) {
+        libertyVersionCache.put(workspaceFolderURI, version);
+    }
+
+    public String getLibertyVersion(String workspaceFolderURI) {
+        return libertyVersionCache.get(workspaceFolderURI);
+    }
+
+    /**
+     * Given a serverXML URI return the corresponding workspace folder URI
+     * 
+     * @param serverXMLUri
+     * @return
+     */
+    public static String getWorkspaceFolder(String serverXMLUri) {
+        for (WorkspaceFolder folder : getInstance().getWorkspaceFolders()) {
+            if (serverXMLUri.contains(folder.getUri())) {
+                return folder.getUri();
+            }
+        }
+        return null;
+    }
+
+    public void cleanUpTempDirs() {
+        for (WorkspaceFolder folder : getInstance().getWorkspaceFolders()) {
+            // search for liberty ls directory
+            String workspaceFolderURI = folder.getUri();
+            try {
+                if (workspaceFolderURI != null) {
+                    URI rootURI = new URI(workspaceFolderURI);
+                    Path rootPath = Paths.get(rootURI);
+                    List<Path> matchingFiles = Files.walk(rootPath)
+                            .filter(p -> (Files.isDirectory(p) && p.getFileName().endsWith(".libertyls")))
+                            .collect(Collectors.toList());
+
+                    // delete each liberty ls directory
+                    for (Path libertylsDir : matchingFiles) {
+                        if (!libertylsDir.toFile().delete()) {
+                            LOGGER.warning("Could not delete " + libertylsDir);
+                        }
+                    }
+
+                }
+            } catch (IOException | URISyntaxException e) {
+                LOGGER.warning("Could not clean up /.libertyls directory: " + e.getMessage());
+            }
+            
+        }
+	}
+
+}

--- a/lemminx-liberty/src/main/java/io/openliberty/lemminx/liberty/services/LibertyProjectsManager.java
+++ b/lemminx-liberty/src/main/java/io/openliberty/lemminx/liberty/services/LibertyProjectsManager.java
@@ -50,7 +50,7 @@ public class LibertyProjectsManager {
      * @param serverXMLUri
      * @return
      */
-    public static LibertyWorkspace getWorkspaceFolder(String serverXMLUri) {
+    public LibertyWorkspace getWorkspaceFolder(String serverXMLUri) {
         for (LibertyWorkspace folder : getInstance().getLibertyWorkspaceFolders()) {
             if (serverXMLUri.contains(folder.getURI())) {
                 return folder;

--- a/lemminx-liberty/src/main/java/io/openliberty/lemminx/liberty/services/LibertyWorkspace.java
+++ b/lemminx-liberty/src/main/java/io/openliberty/lemminx/liberty/services/LibertyWorkspace.java
@@ -1,0 +1,42 @@
+package io.openliberty.lemminx.liberty.services;
+
+public class LibertyWorkspace {
+
+    private String workspaceFolderURI;
+    private String libertyVersion;
+    private boolean isLibertyInstalled;
+
+    /**
+     * Model of a Liberty Workspace. Each workspace indicates the
+     * workspaceFolderURI, the Liberty version associated (may be cached), and if an
+     * installed Liberty instance has been detected.
+     * 
+     * @param workspaceFolderURI
+     */
+    public LibertyWorkspace(String workspaceFolderURI) {
+        this.workspaceFolderURI = workspaceFolderURI;
+        this.libertyVersion = null;
+        this.isLibertyInstalled = false;
+    }
+
+    public String getURI() {
+        return this.workspaceFolderURI;
+    }
+
+    public void setLibertyVersion(String libertyVersion) {
+        this.libertyVersion = libertyVersion;
+    }
+
+    public String getLibertyVersion() {
+        return this.libertyVersion;
+    }
+
+    public void setLibertyInstalled(boolean isLibertyInstalled) {
+        this.isLibertyInstalled = isLibertyInstalled;
+    }
+
+    public boolean isLibertyInstalled() {
+        return this.isLibertyInstalled;
+    }
+
+}

--- a/lemminx-liberty/src/main/java/io/openliberty/lemminx/liberty/services/LibertyWorkspace.java
+++ b/lemminx-liberty/src/main/java/io/openliberty/lemminx/liberty/services/LibertyWorkspace.java
@@ -1,10 +1,16 @@
 package io.openliberty.lemminx.liberty.services;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import io.openliberty.lemminx.liberty.models.feature.Feature;
+
 public class LibertyWorkspace {
 
     private String workspaceFolderURI;
     private String libertyVersion;
     private boolean isLibertyInstalled;
+    private List<Feature> installedFeatureList;
 
     /**
      * Model of a Liberty Workspace. Each workspace indicates the
@@ -17,6 +23,7 @@ public class LibertyWorkspace {
         this.workspaceFolderURI = workspaceFolderURI;
         this.libertyVersion = null;
         this.isLibertyInstalled = false;
+        this.installedFeatureList = new ArrayList<Feature>();
     }
 
     public String getURI() {
@@ -37,6 +44,14 @@ public class LibertyWorkspace {
 
     public boolean isLibertyInstalled() {
         return this.isLibertyInstalled;
+    }
+
+    public List<Feature> getInstalledFeatureList() {
+        return this.installedFeatureList;
+    }
+
+    public void setInstalledFeatureList(List<Feature> installedFeatureList){
+        this.installedFeatureList = installedFeatureList;
     }
 
 }

--- a/lemminx-liberty/src/main/java/io/openliberty/lemminx/liberty/services/SettingsService.java
+++ b/lemminx-liberty/src/main/java/io/openliberty/lemminx/liberty/services/SettingsService.java
@@ -14,8 +14,6 @@ public class SettingsService {
     return instance;
   }
 
-  private static String DEFAULT_SERVER_VERSION = "20.0.0.9";
-
   // default request delay is 120 seconds
   private static int DEFAULT_REQUEST_DELAY = 120;
 
@@ -43,7 +41,7 @@ public class SettingsService {
       }
     }
 
-    return DEFAULT_SERVER_VERSION;
+    return null;
   }
 
   public int getRequestDelay() {

--- a/lemminx-liberty/src/main/java/io/openliberty/lemminx/liberty/util/LibertyConstants.java
+++ b/lemminx-liberty/src/main/java/io/openliberty/lemminx/liberty/util/LibertyConstants.java
@@ -12,4 +12,6 @@ public final class LibertyConstants {
     public static final String FEATURE_ELEMENT = "feature";
 
     public static final String PUBLIC_VISIBILITY = "PUBLIC";
+
+    public static String DEFAULT_SERVER_VERSION = "20.0.0.9";
 }

--- a/lemminx-liberty/src/main/java/io/openliberty/lemminx/liberty/util/LibertyConstants.java
+++ b/lemminx-liberty/src/main/java/io/openliberty/lemminx/liberty/util/LibertyConstants.java
@@ -13,5 +13,8 @@ public final class LibertyConstants {
 
     public static final String PUBLIC_VISIBILITY = "PUBLIC";
 
-    public static String DEFAULT_SERVER_VERSION = "20.0.0.9";
+    public static final String DEFAULT_SERVER_VERSION = "20.0.0.9";
+
+    // used in the feature cache to store the installed feature list
+    public static final String INSTALLED_FEATURE_KEY = "installedFeatures";
 }

--- a/lemminx-liberty/src/main/java/io/openliberty/lemminx/liberty/util/LibertyConstants.java
+++ b/lemminx-liberty/src/main/java/io/openliberty/lemminx/liberty/util/LibertyConstants.java
@@ -15,6 +15,4 @@ public final class LibertyConstants {
 
     public static final String DEFAULT_SERVER_VERSION = "20.0.0.9";
 
-    // used in the feature cache to store the installed feature list
-    public static final String INSTALLED_FEATURE_KEY = "installedFeatures";
 }

--- a/lemminx-liberty/src/main/java/io/openliberty/lemminx/liberty/util/LibertyUtils.java
+++ b/lemminx-liberty/src/main/java/io/openliberty/lemminx/liberty/util/LibertyUtils.java
@@ -1,8 +1,26 @@
 package io.openliberty.lemminx.liberty.util;
 
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.Properties;
+import java.util.logging.Logger;
+import java.util.stream.Collectors;
+
 import org.eclipse.lemminx.dom.DOMDocument;
 
+import io.openliberty.lemminx.liberty.services.LibertyProjectsManager;
+
 public class LibertyUtils {
+
+    private static final Logger LOGGER = Logger.getLogger(LibertyUtils.class.getName());
+
     private LibertyUtils() {
     }
 
@@ -13,4 +31,116 @@ public class LibertyUtils {
     public static boolean isServerXMLFile(DOMDocument file) {
         return file.getDocumentURI().endsWith("/" + LibertyConstants.SERVER_XML);
     }
+
+    /**
+     * Given a server xml uri find the associated workspace folder and search that
+     * folder for the most recently edited file that matches the given name
+     * 
+     * @param serverXmlURI
+     * @param filename
+     * @return path to given file or null if could not be found
+     */
+    public static Path findFileInWorkspace(String serverXmlURI, String filename) {
+
+        String workspaceFolderURI = LibertyProjectsManager.getWorkspaceFolder(serverXmlURI);
+        if (workspaceFolderURI == null) {
+            return null;
+        }
+        try {
+            URI rootURI = new URI(workspaceFolderURI);
+            Path rootPath = Paths.get(rootURI);
+            List<Path> matchingFiles = Files.walk(rootPath)
+                    .filter(p -> (Files.isRegularFile(p) && p.getFileName().endsWith(filename)))
+                    .collect(Collectors.toList());
+            if (matchingFiles.isEmpty()) {
+                return null;
+            }
+            if (matchingFiles.size() == 1) {
+                return matchingFiles.get(0);
+            }
+            Path lastModified = matchingFiles.get(0);
+            for (Path p : matchingFiles) {
+                if (lastModified.toFile().lastModified() < p.toFile().lastModified()) {
+                    lastModified = p;
+                }
+            }
+            return lastModified;
+        } catch (IOException | URISyntaxException e) {
+            LOGGER.warning("Could not find: " + filename + ": " + e.getMessage());
+            return null;
+        }
+    }
+
+    /**
+     * Get the version from the installed Liberty instance Searched for and gets the
+     * version from an openliberty.properties file
+     * 
+     * @param serverXML server xml associated
+     * @return version of Liberty or null
+     */
+    public static String getVersion(DOMDocument serverXML) {
+        // TODO: add logic to determine how often we should check for list of installed
+        // features
+
+        // find workspace folder this serverXML belongs to
+        String workspaceFolderURI = LibertyProjectsManager.getWorkspaceFolder(serverXML.getDocumentURI());
+        if (workspaceFolderURI == null) {
+            return null;
+        }
+        String version;
+
+        LibertyProjectsManager projectsManager = LibertyProjectsManager.getInstance();
+        version = projectsManager.getLibertyVersion(workspaceFolderURI);
+        LOGGER.info("---- version from cache: " + version);
+        if (version == null) {
+            Path propertiesFile = findFileInWorkspace(serverXML.getDocumentURI(), "openliberty.properties");
+            if (propertiesFile != null && propertiesFile.toFile().exists()) {
+                Properties prop = new Properties();
+                try {
+                    FileInputStream fis = new FileInputStream(propertiesFile.toFile());
+                    prop.load(fis);
+                    version = prop.getProperty("com.ibm.websphere.productVersion");
+                    LOGGER.info("---- version from property file: " + version);
+                    projectsManager.updateLibertyVersionCache(workspaceFolderURI, version);
+                    return version;
+                } catch (IOException e) {
+                    LOGGER.warning("Unable to get version from properties file: " + propertiesFile.toString() + ": "
+                            + e.getMessage());
+                    return null;
+                }
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Return temp dir to store generated feature lists and schema Creates temp dir
+     * if it does not exist
+     * 
+     * @param folder
+     * @return
+     */
+    public static File getTempDir(String workspaceFolderURI) {
+        if (workspaceFolderURI == null) {
+            return null;
+        }
+        try {
+            URI rootURI = new URI(workspaceFolderURI);
+            Path rootPath = Paths.get(rootURI);
+            File file = rootPath.toFile();
+            File libertyLSFolder = new File(file, ".libertyls");
+
+            if (!libertyLSFolder.exists()) {
+                if (!libertyLSFolder.mkdir()) {
+                    return null;
+                }
+            }
+            return file;
+        } catch (Exception e) {
+            // unable to create temp dir
+            LOGGER.warning("Unable to create temp dir: " + e.getMessage());
+        }
+        return null;
+    }
+
 }

--- a/lemminx-liberty/src/main/java/io/openliberty/lemminx/liberty/util/LibertyUtils.java
+++ b/lemminx-liberty/src/main/java/io/openliberty/lemminx/liberty/util/LibertyUtils.java
@@ -22,6 +22,7 @@ import org.eclipse.lemminx.dom.DOMDocument;
 import io.openliberty.lemminx.liberty.services.FeatureService;
 import io.openliberty.lemminx.liberty.services.LibertyProjectsManager;
 import io.openliberty.lemminx.liberty.services.LibertyWorkspace;
+import io.openliberty.lemminx.liberty.services.SettingsService;
 
 public class LibertyUtils {
 
@@ -80,7 +81,7 @@ public class LibertyUtils {
 
     /**
      * Given a server.xml find the version associated with the corresponding Liberty
-     * workspace. If the version has not been set, search for an
+     * workspace. If the version has not been set via the Settings Service, search for an
      * openliberty.properties file in the workspace and return the version from that
      * file. Otherwise, return null.
      * 
@@ -88,6 +89,11 @@ public class LibertyUtils {
      * @return version of Liberty or null
      */
     public static String getVersion(DOMDocument serverXML) {
+        // return version set in settings if it exists
+        String libertyVersion = SettingsService.getInstance().getLibertyVersion();
+        if (libertyVersion != null) {
+            return libertyVersion;
+        }
         // find workspace folder this serverXML belongs to
         LibertyWorkspace libertyWorkspace = LibertyProjectsManager.getInstance().getWorkspaceFolder(serverXML.getDocumentURI());
 

--- a/lemminx-liberty/src/main/java/io/openliberty/lemminx/liberty/util/LibertyUtils.java
+++ b/lemminx-liberty/src/main/java/io/openliberty/lemminx/liberty/util/LibertyUtils.java
@@ -49,7 +49,7 @@ public class LibertyUtils {
      * @return path to given file or null if could not be found
      */
     public static Path findFileInWorkspace(String serverXmlURI, String filename) {
-        LibertyWorkspace libertyWorkspace = LibertyProjectsManager.getWorkspaceFolder(serverXmlURI);
+        LibertyWorkspace libertyWorkspace = LibertyProjectsManager.getInstance().getWorkspaceFolder(serverXmlURI);
         if (libertyWorkspace.getURI() == null) {
             return null;
         }
@@ -89,7 +89,7 @@ public class LibertyUtils {
      */
     public static String getVersion(DOMDocument serverXML) {
         // find workspace folder this serverXML belongs to
-        LibertyWorkspace libertyWorkspace = LibertyProjectsManager.getWorkspaceFolder(serverXML.getDocumentURI());
+        LibertyWorkspace libertyWorkspace = LibertyProjectsManager.getInstance().getWorkspaceFolder(serverXML.getDocumentURI());
 
         if (libertyWorkspace == null || libertyWorkspace.getURI() == null) {
             return null;

--- a/lemminx-liberty/src/main/java/io/openliberty/lemminx/liberty/util/LibertyUtils.java
+++ b/lemminx-liberty/src/main/java/io/openliberty/lemminx/liberty/util/LibertyUtils.java
@@ -11,6 +11,7 @@ import java.nio.file.Paths;
 import java.nio.file.StandardWatchEventKinds;
 import java.nio.file.WatchKey;
 import java.nio.file.WatchService;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
@@ -19,7 +20,7 @@ import java.util.stream.Collectors;
 
 import org.eclipse.lemminx.dom.DOMDocument;
 
-import io.openliberty.lemminx.liberty.services.FeatureService;
+import io.openliberty.lemminx.liberty.models.feature.Feature;
 import io.openliberty.lemminx.liberty.services.LibertyProjectsManager;
 import io.openliberty.lemminx.liberty.services.LibertyWorkspace;
 import io.openliberty.lemminx.liberty.services.SettingsService;
@@ -111,10 +112,10 @@ public class LibertyUtils {
 
         // detected a new Liberty properties file, re-calculate version
         if (propertiesFile != null && propertiesFile.toFile().exists()) {
-            // new properties file, remove the installed features from the feature cache
+            // new properties file, reset the installed features stored in the feature cache
             // so that the installed features list will be regenerated as it may have
             // changed between Liberty installations
-            FeatureService.getInstance().removeFromFeatureCache(LibertyConstants.INSTALLED_FEATURE_KEY);
+            libertyWorkspace.setInstalledFeatureList(new ArrayList<Feature>());
             Properties prop = new Properties();
             try {
                 // add a file watcher on this file


### PR DESCRIPTION
Fixes #20 

Added the following functionality:
1) Determine the Liberty version from the `openliberty.properties` file found in the workspace.
When a new properties file is detected, we watch this file in a separate thread. If this file is modified or the enclosing folder is deleted, we treat this as the Liberty installation being modified. The associated `isLibertyInstalled` value (see workspace folders below) is set to `false`.

2) Track workspace folders
See the `LibertyWorkspace.java` class. Each workspace folder has an associated URI, Liberty version, and `isLibertyInstalled` value. The Liberty version is used as the version cache. The `isLibertyInstalled` value is used to determine whether the LS should look for a new `openliberty.properties` file.

3) If the features list cannot be retrieved from Maven, fallback to a list of installed features.
Uses the `ws-featureslist.jar` to generate the list of installed features. Generates a featurelist.xml document into the LemMinx cache. Then uses the existing `Feature.java` class and the new `FeatureInfo.java` class to parse the xml document into a feature list. Only the `name`, `description`, and `shortDescription` are set for the installed features.
![image](https://user-images.githubusercontent.com/26146482/106508437-65c3bd00-649a-11eb-80f1-3c5739f2b29d.png)
