### PR TITLE
Add launch.json for attaching java debugger

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -7,7 +7,7 @@
 		{
 			"type": "java",
 			"request": "attach",
-			"name": "Debug Attach to lemminx",
+			"name": "Debug attach liberty-lemminx",
 			"hostName": "localhost",
 			"projectName": "liberty-langserver-lemminx",
 			"port": 1054

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,16 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+		{
+			"type": "java",
+			"request": "attach",
+			"name": "Debug Attach to lemminx",
+			"hostName": "localhost",
+			"projectName": "liberty-langserver-lemminx",
+			"port": 1054
+		}
+	]
+}

--- a/README.md
+++ b/README.md
@@ -12,3 +12,23 @@ Monorepo for projects providing IDE / language support for Open Liberty using th
 ## Building with VS Code
 
 To build the language server for Liberty configuration prototype with a VS Code Client, see the [liberty-ls-prototype branch](https://github.com/OpenLiberty/open-liberty-tools-vscode/tree/liberty-ls-prototype) of the Open Liberty Tools VS Code extension.
+
+## Debugging with VS Code
+
+Prerequisites: [Debugger for Java extension](https://marketplace.visualstudio.com/items?itemName=vscjava.vscode-java-debug) for VS Code
+
+1. Create a VS Code workspace with both [open-liberty-tools-vscode](https://github.com/OpenLiberty/open-liberty-tools-vscode) and this project at the root of the workspace. The folder structure should look something like this:
+```
+| > open-liberty-tools-vscode
+| v liberty-language-server
+| | > lemminx-liberty
+| | > liberty-ls
+```
+
+2. In the `open-liberty-tools-vscode` directory, run `npm run build`.
+
+3. Open the debug view, select and launch `Run Extension (open-liberty-tools-vscode)`. It will open a new window with the extension running in debug mode.
+
+4. In the same debug view, now select and launch one of the following to debug each respective project:
+    * `Debug attach liberty-lemminx`
+    * `Debug attach liberty-ls` (in progress)


### PR DESCRIPTION
To debug, have both `open-liberty-tools-vscode` and `liberty-language-server` projects at the root of VS Code workspace.
![image](https://user-images.githubusercontent.com/689163/163598521-8dbe14b0-3c4d-46d6-a7eb-1cc191c65bb5.png)

Run `npm run build` in `open-liberty-tools-vscode`

Run `Run Extension` first, a new VS Code window will open with the extension running.
Then run `Debug Attach to lemminx`
![image](https://user-images.githubusercontent.com/689163/163598375-a2f0ba9f-81ba-4c7d-b069-c4f5fd31c25f.png)

Set your breakpoints and use the new VS Code window to trigger actions (ie. hover or completion)