### PR TITLE
Enable Lang Server for more Config Files

### DIFF
--- a/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/LibertyCompletionParticipant.java
+++ b/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/LibertyCompletionParticipant.java
@@ -43,7 +43,7 @@ public class LibertyCompletionParticipant extends CompletionParticipantAdapter {
     @Override
     public void onXMLContent(ICompletionRequest request, ICompletionResponse response, CancelChecker cancelChecker)
             throws IOException, BadLocationException {
-        if (!LibertyUtils.isServerXMLFile(request.getXMLDocument()))
+        if (!LibertyUtils.isConfigXMLFile(request.getXMLDocument()))
             return;    
 
         LibertyUtils.getVersion(request.getXMLDocument());

--- a/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/LibertyDiagnosticParticipant.java
+++ b/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/LibertyDiagnosticParticipant.java
@@ -61,7 +61,7 @@ public class LibertyDiagnosticParticipant implements IDiagnosticsParticipant {
         
     }
 
-    private void validateFeature(DOMDocument domDocument, List<Diagnostic> list, DOMNode node) {
+    private void validateFeature(DOMDocument domDocument, List<Diagnostic> list, DOMNode featureManager) {
         String libertyVersion =  LibertyUtils.getVersion(domDocument);
 
         final int requestDelay = SettingsService.getInstance().getRequestDelay();
@@ -69,7 +69,7 @@ public class LibertyDiagnosticParticipant implements IDiagnosticsParticipant {
         // Search for duplicate features
         // or features that do not exist
         Set<String> includedFeatures = new HashSet<>();
-        List<DOMNode> features = node.getChildren();
+        List<DOMNode> features = featureManager.getChildren();
         for (DOMNode featureNode : features) {
             DOMNode featureTextNode = (DOMNode) featureNode.getChildNodes().item(0);
             // skip nodes that do not have any text value (ie. comments)

--- a/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/LibertyDiagnosticParticipant.java
+++ b/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/LibertyDiagnosticParticipant.java
@@ -104,7 +104,7 @@ public class LibertyDiagnosticParticipant implements IDiagnosticsParticipant {
         String docURIString = domDocument.getDocumentURI().replace(File.separator, "/");    // URI requires
         locAttribute = locAttribute.replace(File.separator, "/");
         File configFile = locAttribute.startsWith("./") ? 
-                new File(URI.create(docURIString.substring(0, docURIString.lastIndexOf(File.separator) + 1))
+                new File(URI.create(docURIString.substring(0, docURIString.lastIndexOf("/") + 1))
                         .resolve(locAttribute).normalize()) :
                 new File(locAttribute);
 

--- a/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/LibertyDiagnosticParticipant.java
+++ b/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/LibertyDiagnosticParticipant.java
@@ -102,6 +102,7 @@ public class LibertyDiagnosticParticipant implements IDiagnosticsParticipant {
             return;
         }
         String docURIString = domDocument.getDocumentURI();
+        locAttribute = locAttribute.replace("/", File.separator);
         File configFile = locAttribute.startsWith("." + File.separator) ? 
                 new File(URI.create(docURIString.substring(0, docURIString.lastIndexOf(File.separator) + 1)).resolve(locAttribute).normalize()) :
                 new File(locAttribute);

--- a/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/LibertyDiagnosticParticipant.java
+++ b/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/LibertyDiagnosticParticipant.java
@@ -101,10 +101,11 @@ public class LibertyDiagnosticParticipant implements IDiagnosticsParticipant {
         if (locAttribute == null) {
             return;
         }
-        String docURIString = domDocument.getDocumentURI();
+        String docURIString = domDocument.getDocumentURI().replace(File.separator, "/");    // URI requires
         locAttribute = locAttribute.replace(File.separator, "/");
-        File configFile = locAttribute.startsWith("." + File.separator) ? 
-                new File(URI.create(docURIString.substring(0, docURIString.lastIndexOf(File.separator) + 1)).resolve(locAttribute).normalize()) :
+        File configFile = locAttribute.startsWith("./") ? 
+                new File(URI.create(docURIString.substring(0, docURIString.lastIndexOf(File.separator) + 1))
+                        .resolve(locAttribute).normalize()) :
                 new File(locAttribute);
 
         DOMNode locNode = node.getAttributeNode("location");
@@ -114,11 +115,11 @@ public class LibertyDiagnosticParticipant implements IDiagnosticsParticipant {
                 LibertyProjectsManager.getInstance().getWorkspaceFolder(docURIString).addConfigFile(configFile.getCanonicalPath());
             } else {
                 String message = "The file at the specified location could not be found.";
-                list.add(new Diagnostic(range, message, DiagnosticSeverity.Warning, "liberty-lemminx"));
+                list.add(new Diagnostic(range, message, DiagnosticSeverity.Hint, "liberty-lemminx"));
             }
         } catch (IllegalArgumentException | IOException e) {
             String message = "The file at the specified location could not be found.";
-            list.add(new Diagnostic(range, message, DiagnosticSeverity.Warning, "liberty-lemminx"));
+            list.add(new Diagnostic(range, message, DiagnosticSeverity.Hint, "liberty-lemminx-exception"));
         }
     }
 }

--- a/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/LibertyDiagnosticParticipant.java
+++ b/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/LibertyDiagnosticParticipant.java
@@ -102,7 +102,7 @@ public class LibertyDiagnosticParticipant implements IDiagnosticsParticipant {
             return;
         }
         String docURIString = domDocument.getDocumentURI();
-        locAttribute = locAttribute.replace("/", File.separator);
+        locAttribute = locAttribute.replace(File.separator, "/");
         File configFile = locAttribute.startsWith("." + File.separator) ? 
                 new File(URI.create(docURIString.substring(0, docURIString.lastIndexOf(File.separator) + 1)).resolve(locAttribute).normalize()) :
                 new File(locAttribute);

--- a/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/LibertyHoverParticipant.java
+++ b/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/LibertyHoverParticipant.java
@@ -44,7 +44,7 @@ public class LibertyHoverParticipant implements IHoverParticipant {
 
 	@Override
 	public Hover onText(IHoverRequest request) {
-		if (!LibertyUtils.isServerXMLFile(request.getXMLDocument()))
+		if (!LibertyUtils.isConfigXMLFile(request.getXMLDocument()))
 			return null;
 
 		DOMElement parentElement = request.getParentElement();

--- a/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/LibertyXSDURIResolver.java
+++ b/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/LibertyXSDURIResolver.java
@@ -45,7 +45,7 @@ public class LibertyXSDURIResolver implements URIResolverExtension, IExternalGra
       XSD_CLASSPATH_LOCATION);
 
   public String resolve(String baseLocation, String publicId, String systemId) {
-    if (LibertyUtils.isServerXMLFile(baseLocation)) {
+    if (LibertyUtils.isConfigXMLFile(baseLocation)) {
       try {
         Path serverXSDCacheFile = CacheResourcesManager.getResourceCachePath(SERVER_XSD_RESOURCE);
         return serverXSDCacheFile.toFile().toURI().toString();

--- a/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/services/FeatureService.java
+++ b/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/services/FeatureService.java
@@ -195,7 +195,7 @@ public class FeatureService {
     List<Feature> installedFeatures = new ArrayList<Feature>();
     try {
       LibertyWorkspace libertyWorkspace = LibertyProjectsManager.getInstance().getWorkspaceFolder(documentURI);
-      if (libertyWorkspace == null || libertyWorkspace.getURI() == null) {
+      if (libertyWorkspace == null || libertyWorkspace.getWorkspaceString() == null) {
         return installedFeatures;
       }
 

--- a/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/services/LibertyProjectsManager.java
+++ b/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/services/LibertyProjectsManager.java
@@ -14,7 +14,6 @@ package io.openliberty.tools.langserver.lemminx.services;
 
 import java.io.IOException;
 import java.net.URI;
-import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -64,7 +63,7 @@ public class LibertyProjectsManager {
      */
     public LibertyWorkspace getWorkspaceFolder(String serverXMLUri) {
         for (LibertyWorkspace folder : getInstance().getLibertyWorkspaceFolders()) {
-            if (serverXMLUri.contains(folder.getURI())) {
+            if (serverXMLUri.contains(folder.getWorkspaceString())) {
                 return folder;
             }
         }
@@ -74,11 +73,10 @@ public class LibertyProjectsManager {
     public void cleanUpTempDirs() {
         for (LibertyWorkspace folder : getInstance().getLibertyWorkspaceFolders()) {
             // search for liberty ls directory
-            String workspaceFolderURI = folder.getURI();
+            URI workspaceFolderURI = folder.getWorkspaceURI();
             try {
                 if (workspaceFolderURI != null) {
-                    URI rootURI = new URI(workspaceFolderURI);
-                    Path rootPath = Paths.get(rootURI);
+                    Path rootPath = Paths.get(workspaceFolderURI);
                     List<Path> matchingFiles = Files.walk(rootPath)
                             .filter(p -> (Files.isDirectory(p) && p.getFileName().endsWith(".libertyls")))
                             .collect(Collectors.toList());
@@ -90,7 +88,7 @@ public class LibertyProjectsManager {
                         }
                     }
                 }
-            } catch (IOException | URISyntaxException e) {
+            } catch (IOException e) {
                 LOGGER.warning("Could not clean up /.libertyls directory: " + e.getMessage());
             }
         }

--- a/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/services/LibertyWorkspace.java
+++ b/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/services/LibertyWorkspace.java
@@ -12,8 +12,12 @@
 *******************************************************************************/
 package io.openliberty.tools.langserver.lemminx.services;
 
+import java.io.File;
+import java.io.IOException;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import io.openliberty.tools.langserver.lemminx.models.feature.Feature;
 
@@ -23,6 +27,7 @@ public class LibertyWorkspace {
     private String libertyVersion;
     private boolean isLibertyInstalled;
     private List<Feature> installedFeatureList;
+    private Set<String> configFiles;
 
     /**
      * Model of a Liberty Workspace. Each workspace indicates the
@@ -36,6 +41,7 @@ public class LibertyWorkspace {
         this.libertyVersion = null;
         this.isLibertyInstalled = false;
         this.installedFeatureList = new ArrayList<Feature>();
+        this.configFiles = new HashSet<String>();
     }
 
     public String getURI() {
@@ -62,8 +68,16 @@ public class LibertyWorkspace {
         return this.installedFeatureList;
     }
 
-    public void setInstalledFeatureList(List<Feature> installedFeatureList){
+    public void setInstalledFeatureList(List<Feature> installedFeatureList) {
         this.installedFeatureList = installedFeatureList;
+    }
+
+    public void addConfigFile(String fileString) {
+        configFiles.add(fileString);
+    }
+
+    public boolean hasConfigFile(String URI) throws IOException {
+        return this.configFiles.contains(new File(URI).getCanonicalPath());
     }
 
 }

--- a/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/util/LibertyConstants.java
+++ b/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/util/LibertyConstants.java
@@ -12,6 +12,8 @@
 *******************************************************************************/
 package io.openliberty.tools.langserver.lemminx.util;
 
+import java.io.File;
+
 public final class LibertyConstants {
     private LibertyConstants() {
     }
@@ -28,4 +30,7 @@ public final class LibertyConstants {
 
     public static final String DEFAULT_SERVER_VERSION = "20.0.0.9";
 
+    public static final String WLP_USER_CONFIG_DIR = String.join(File.separator, "usr", "shared", "config");
+    public static final String SERVER_CONFIG_DROPINS_DEFAULTS = String.join(File.separator, "configDropins", "defaults");
+    public static final String SERVER_CONFIG_DROPINS_OVERRIDES = String.join(File.separator, "configDropins", "overrides");
 }

--- a/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/util/LibertyConstants.java
+++ b/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/util/LibertyConstants.java
@@ -30,7 +30,7 @@ public final class LibertyConstants {
 
     public static final String DEFAULT_SERVER_VERSION = "20.0.0.9";
 
-    public static final String WLP_USER_CONFIG_DIR = String.join(File.separator, "usr", "shared", "config");
-    public static final String SERVER_CONFIG_DROPINS_DEFAULTS = String.join(File.separator, "configDropins", "defaults");
-    public static final String SERVER_CONFIG_DROPINS_OVERRIDES = String.join(File.separator, "configDropins", "overrides");
+    public static final String WLP_USER_CONFIG_DIR = File.separator + String.join(File.separator, "usr", "shared", "config") + File.separator;
+    public static final String SERVER_CONFIG_DROPINS_DEFAULTS = File.separator + String.join(File.separator, "configDropins", "defaults") + File.separator;
+    public static final String SERVER_CONFIG_DROPINS_OVERRIDES = File.separator + String.join(File.separator, "configDropins", "overrides") + File.separator;
 }

--- a/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/util/LibertyConstants.java
+++ b/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/util/LibertyConstants.java
@@ -22,6 +22,7 @@ public final class LibertyConstants {
 
     public static final String FEATURE_MANAGER_ELEMENT = "featureManager";
     public static final String FEATURE_ELEMENT = "feature";
+    public static final String INCLUDE_ELEMENT = "include";
 
     public static final String PUBLIC_VISIBILITY = "PUBLIC";
 

--- a/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/util/LibertyUtils.java
+++ b/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/util/LibertyUtils.java
@@ -55,12 +55,7 @@ public class LibertyUtils {
     }
 
     public static boolean isConfigXMLFile(String filePath) {
-        try {
-            return isServerXMLFile(filePath) || 
-                LibertyProjectsManager.getInstance().getWorkspaceFolder(filePath).hasConfigFile(filePath);
-        } catch (IOException e) {
-            return isServerXMLFile(filePath) || false;
-        }
+        return LibertyProjectsManager.getInstance().getWorkspaceFolder(filePath).hasConfigFile(filePath) || isServerXMLFile(filePath);
     }
 
     public static boolean isConfigXMLFile(DOMDocument file) {
@@ -77,12 +72,11 @@ public class LibertyUtils {
      */
     public static Path findFileInWorkspace(String serverXmlURI, String filename) {
         LibertyWorkspace libertyWorkspace = LibertyProjectsManager.getInstance().getWorkspaceFolder(serverXmlURI);
-        if (libertyWorkspace.getURI() == null) {
+        if (libertyWorkspace.getWorkspaceURI() == null) {
             return null;
         }
         try {
-            URI rootURI = new URI(libertyWorkspace.getURI());
-            Path rootPath = Paths.get(rootURI);
+            Path rootPath = Paths.get(libertyWorkspace.getWorkspaceURI());
             List<Path> matchingFiles = Files.walk(rootPath)
                     .filter(p -> (Files.isRegularFile(p) && p.getFileName().endsWith(filename)))
                     .collect(Collectors.toList());
@@ -99,7 +93,7 @@ public class LibertyUtils {
                 }
             }
             return lastModified;
-        } catch (IOException | URISyntaxException e) {
+        } catch (IOException e) {
             LOGGER.warning("Could not find: " + filename + ": " + e.getMessage());
             return null;
         }
@@ -123,7 +117,7 @@ public class LibertyUtils {
         // find workspace folder this serverXML belongs to
         LibertyWorkspace libertyWorkspace = LibertyProjectsManager.getInstance().getWorkspaceFolder(serverXML.getDocumentURI());
 
-        if (libertyWorkspace == null || libertyWorkspace.getURI() == null) {
+        if (libertyWorkspace == null || libertyWorkspace.getWorkspaceString() == null) {
             return null;
         }
 

--- a/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/util/LibertyUtils.java
+++ b/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/util/LibertyUtils.java
@@ -14,8 +14,6 @@ package io.openliberty.tools.langserver.lemminx.util;
 
 import java.io.FileInputStream;
 import java.io.IOException;
-import java.net.URI;
-import java.net.URISyntaxException;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -54,8 +52,15 @@ public class LibertyUtils {
         return file.getDocumentURI().endsWith("/" + LibertyConstants.SERVER_XML);
     }
 
+    public static boolean isConfigDirFile(String filePath) {
+        return filePath.contains(LibertyConstants.WLP_USER_CONFIG_DIR) ||
+                filePath.contains(LibertyConstants.SERVER_CONFIG_DROPINS_DEFAULTS) ||
+                filePath.contains(LibertyConstants.SERVER_CONFIG_DROPINS_OVERRIDES);
+    }
+
     public static boolean isConfigXMLFile(String filePath) {
-        return isServerXMLFile(filePath) || LibertyProjectsManager.getInstance().getWorkspaceFolder(filePath).hasConfigFile(filePath);
+        return isServerXMLFile(filePath) || isConfigDirFile(filePath) ||
+                LibertyProjectsManager.getInstance().getWorkspaceFolder(filePath).hasConfigFile(filePath);
     }
 
     public static boolean isConfigXMLFile(DOMDocument file) {

--- a/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/util/LibertyUtils.java
+++ b/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/util/LibertyUtils.java
@@ -55,7 +55,7 @@ public class LibertyUtils {
     }
 
     public static boolean isConfigXMLFile(String filePath) {
-        return LibertyProjectsManager.getInstance().getWorkspaceFolder(filePath).hasConfigFile(filePath) || isServerXMLFile(filePath);
+        return isServerXMLFile(filePath) || LibertyProjectsManager.getInstance().getWorkspaceFolder(filePath).hasConfigFile(filePath);
     }
 
     public static boolean isConfigXMLFile(DOMDocument file) {

--- a/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/util/LibertyUtils.java
+++ b/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/util/LibertyUtils.java
@@ -54,6 +54,19 @@ public class LibertyUtils {
         return file.getDocumentURI().endsWith("/" + LibertyConstants.SERVER_XML);
     }
 
+    public static boolean isConfigXMLFile(String filePath) {
+        try {
+            return isServerXMLFile(filePath) || 
+                LibertyProjectsManager.getInstance().getWorkspaceFolder(filePath).hasConfigFile(filePath);
+        } catch (IOException e) {
+            return isServerXMLFile(filePath) || false;
+        }
+    }
+
+    public static boolean isConfigXMLFile(DOMDocument file) {
+        return isConfigXMLFile(file.getDocumentURI());
+    }
+
     /**
      * Given a server.xml URI find the associated workspace folder and search that
      * folder for the most recently edited file that matches the given name.

--- a/lemminx-liberty/src/test/java/io/openliberty/LibertyDiagnosticTest.java
+++ b/lemminx-liberty/src/test/java/io/openliberty/LibertyDiagnosticTest.java
@@ -81,6 +81,9 @@ public class LibertyDiagnosticTest {
                 "<server description=\"default server\">", //
                 "    <include optional=\"true\" location=\"./empty_server.xml\"/>", //
                 "    <include optional=\"false\" location=\"MISSING FILE\"/>", //
+                "    <include", //
+                "            optional=\"true\" location=\"MULTI LINER\"/>", //
+                "    <include optional=\"false\" location=\"MISSING FILE.xml\"/>", //
                 "</server>"
         );
         // Diagnostic location1 = new Diagnostic();
@@ -91,13 +94,26 @@ public class LibertyDiagnosticTest {
 
         Diagnostic location2 = new Diagnostic();
         location2.setRange(r(2, 30, 2, 53));
-        location2.setMessage("The file at the specified location could not be found.");
-        XMLAssert.testDiagnosticsFor(serverXML, null, null, serverXMLFile.toURI().toString(), location2);
+        location2.setMessage("The specified file is not an XML file.");
+
+        Diagnostic location3 = new Diagnostic();
+        location3.setRange(r(4, 28, 4, 50));
+        location3.setMessage("The specified file is not an XML file.");
         
+        Diagnostic location4 = new Diagnostic();
+        location4.setRange(r(5, 30, 5, 57));
+        location4.setMessage("The file at the specified location could not be found.");
+
+
+        XMLAssert.testDiagnosticsFor(serverXML, null, null, serverXMLFile.toURI().toString(), location2, location3, location4);
+
         assertTrue(LibertyProjectsManager.getInstance().getLibertyWorkspaceFolders().get(0)
                 .hasConfigFile(new File("src/test/resources/empty_server.xml").getCanonicalPath()));
-
         assertFalse(LibertyProjectsManager.getInstance().getLibertyWorkspaceFolders().get(0)
                 .hasConfigFile("MISSING FILE"));
+        assertFalse(LibertyProjectsManager.getInstance().getLibertyWorkspaceFolders().get(0)
+                .hasConfigFile("MULTI LINER"));
+        assertFalse(LibertyProjectsManager.getInstance().getLibertyWorkspaceFolders().get(0)
+                .hasConfigFile("MISSING FILE.xml"));
     }
 }


### PR DESCRIPTION
For #40:

`isServerXMLFile` expanded into `isConfigXMLFile`, where now, a cache tracks files found in `configDropins` and files found in `server.xml`'s `include` tags.

The cache is first built when a `LibertyWorkspace` is initialized upon startup. Changes made to known config files will trigger Diagnostics, which provide warning when the pointed file is not found.

Diagnostics Warning Example:
![image](https://user-images.githubusercontent.com/8934136/164265699-0dbf7513-b286-4da4-81eb-5c2c1293b163.png)

As example, `missing.xml` has hover features from being pointed to by the `server.xml` above.
![image](https://user-images.githubusercontent.com/8934136/164266303-ff6d6dae-eb62-4623-85c5-065de14ff087.png)
