### PR TITLE
init Code Actions + Some Config File Additions

### DIFF
--- a/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/LibertyCodeActionParticipant.java
+++ b/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/LibertyCodeActionParticipant.java
@@ -1,0 +1,58 @@
+/*******************************************************************************
+* Copyright (c) 2022 IBM Corporation and others.
+*
+* This program and the accompanying materials are made available under the
+* terms of the Eclipse Public License v. 2.0 which is available at
+* http://www.eclipse.org/legal/epl-2.0.
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*     IBM Corporation - initial API and implementation
+*******************************************************************************/
+
+package io.openliberty.tools.langserver.lemminx;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.eclipse.lemminx.dom.DOMDocument;
+import org.eclipse.lemminx.services.extensions.ICodeActionParticipant;
+import org.eclipse.lemminx.services.extensions.IComponentProvider;
+import org.eclipse.lemminx.settings.SharedSettings;
+import org.eclipse.lsp4j.CodeAction;
+import org.eclipse.lsp4j.Diagnostic;
+import org.eclipse.lsp4j.Range;
+
+import io.openliberty.tools.langserver.lemminx.codeactions.CreateFile;
+import io.openliberty.tools.langserver.lemminx.codeactions.EditAttribute;
+
+public class LibertyCodeActionParticipant implements ICodeActionParticipant {
+    
+    private final Map<String, ICodeActionParticipant> codeActionParticipants;
+
+    public LibertyCodeActionParticipant() {
+        codeActionParticipants = new HashMap<>();
+    }
+
+    @Override
+    public void doCodeAction(Diagnostic diagnostic, Range range, DOMDocument document, List<CodeAction> codeActions,
+            SharedSettings sharedSettings, IComponentProvider componentProvider) {
+        if (diagnostic == null || diagnostic.getCode() == null || !diagnostic.getCode().isLeft()) {
+            return;
+        }
+        registerCodeActions(sharedSettings);
+        ICodeActionParticipant participant = codeActionParticipants.get(diagnostic.getCode().getLeft());
+        if (participant != null) {
+            participant.doCodeAction(diagnostic, range, document, codeActions, sharedSettings, componentProvider);
+        }
+    }
+
+    private void registerCodeActions(SharedSettings sharedSettings) {
+        if (codeActionParticipants.isEmpty()) {
+            codeActionParticipants.put(LibertyDiagnosticParticipant.MISSING_FILE_CODE, new CreateFile());
+            codeActionParticipants.put(LibertyDiagnosticParticipant.NOT_OPTIONAL_CODE, new EditAttribute());
+        }
+    }
+}

--- a/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/LibertyCodeActionParticipant.java
+++ b/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/LibertyCodeActionParticipant.java
@@ -25,6 +25,7 @@ import org.eclipse.lsp4j.CodeAction;
 import org.eclipse.lsp4j.Diagnostic;
 import org.eclipse.lsp4j.Range;
 
+import io.openliberty.tools.langserver.lemminx.codeactions.AddAttribute;
 import io.openliberty.tools.langserver.lemminx.codeactions.CreateFile;
 import io.openliberty.tools.langserver.lemminx.codeactions.EditAttribute;
 
@@ -53,6 +54,7 @@ public class LibertyCodeActionParticipant implements ICodeActionParticipant {
         if (codeActionParticipants.isEmpty()) {
             codeActionParticipants.put(LibertyDiagnosticParticipant.MISSING_FILE_CODE, new CreateFile());
             codeActionParticipants.put(LibertyDiagnosticParticipant.NOT_OPTIONAL_CODE, new EditAttribute());
+            codeActionParticipants.put(LibertyDiagnosticParticipant.IMPLICIT_NOT_OPTIONAL_CODE, new AddAttribute());
         }
     }
 }

--- a/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/LibertyDiagnosticParticipant.java
+++ b/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/LibertyDiagnosticParticipant.java
@@ -137,7 +137,7 @@ public class LibertyDiagnosticParticipant implements IDiagnosticsParticipant {
             if (configFile.exists()) {
                 LibertyProjectsManager.getInstance().getWorkspaceFolder(domDocument.getDocumentURI()).addConfigFile(configFile.getCanonicalPath());
             } else {
-                if (optString != null && required) {
+                if (required) {
                     DOMNode optNode = node.getAttributeNode("optional");
                     Range optRange = XMLPositionUtility.createRange(optNode.getStart(), optNode.getEnd(), domDocument);
                     list.add(new Diagnostic(optRange, "The specified resource cannot be skipped. Check location value or set optional to true.", 

--- a/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/LibertyDiagnosticParticipant.java
+++ b/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/LibertyDiagnosticParticipant.java
@@ -28,17 +28,15 @@ import io.openliberty.tools.langserver.lemminx.util.*;
 
 import java.io.File;
 import java.io.IOException;
-import java.net.URI;
-import java.util.*;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 
 public class LibertyDiagnosticParticipant implements IDiagnosticsParticipant {
 
     public static final String MISSING_FILE_CODE = "missing_file";
-    public static final String MISSING_FILE_MESSAGE = "The resource at the specified location could not be found:\n";
-
     public static final String NOT_OPTIONAL_CODE = "not_optional";
-    public static final String NOT_OPTIONAL_MESSAGE = "The specified resource cannot be skipped. Check location value or set optional to true.";
-
+    
     @Override
     public void doDiagnostics(DOMDocument domDocument, List<Diagnostic> diagnostics,
             XMLValidationSettings validationSettings, CancelChecker cancelChecker) {
@@ -59,7 +57,7 @@ public class LibertyDiagnosticParticipant implements IDiagnosticsParticipant {
             if (LibertyConstants.FEATURE_MANAGER_ELEMENT.equals(node.getNodeName())) {
                 validateFeature(domDocument, list, node);
             } else if (LibertyConstants.INCLUDE_ELEMENT.equals(node.getNodeName())) {
-                monitorConfigFiles(domDocument, list, node);
+                validateIncludeLocation(domDocument, list, node);
             }
         }
         
@@ -100,17 +98,29 @@ public class LibertyDiagnosticParticipant implements IDiagnosticsParticipant {
         }
     }
 
-    private void monitorConfigFiles(DOMDocument domDocument, List<Diagnostic> list, DOMNode node) {
+    /**
+     * Location checks:
+     * 1) Relative path; 2) Server config dir; 
+     * 3) Absolute path; 4) Web server
+     * 
+     * Checks in method: 1), 3)
+     * 2) performed in isConfigXMLFile
+     * 4) not yet implemented/determined
+     */
+    private void validateIncludeLocation(DOMDocument domDocument, List<Diagnostic> list, DOMNode node) {
         String locAttribute = node.getAttribute("location");
         if (locAttribute == null) {
+            return;
+        }
+        // skip diagnostic for not yet implemented behaviors/checks (URL + vars)
+        if (locAttribute.startsWith("http") || locAttribute.contains("$")) {
             return;
         }
 
         DOMNode locNode = node.getAttributeNode("location");
         Range range = XMLPositionUtility.createRange(locNode.getStart(), locNode.getEnd(), domDocument);
-
         if (!locAttribute.endsWith(".xml")) {
-            String message = "The specified file is not an XML file.";
+            String message = "The specified resource is not an XML file.";
             list.add(new Diagnostic(range, message, DiagnosticSeverity.Warning, "liberty-lemminx"));
             return;
         }
@@ -118,28 +128,26 @@ public class LibertyDiagnosticParticipant implements IDiagnosticsParticipant {
         String optString = node.getAttribute("optional");
         boolean required = optString == null ? false : optString.equals("false");
 
-        String docURIString = domDocument.getDocumentURI().replace(File.separator, "/");
-        locAttribute = locAttribute.replace(File.separator, "/");
-        File configFile = locAttribute.startsWith("./") ? 
-                new File(URI.create(docURIString.substring(0, docURIString.lastIndexOf("/") + 1))
-                        .resolve(locAttribute).normalize()) :
-                new File(locAttribute);
-
+        File docParentFile = LibertyUtils.getDocumentAsFile(domDocument).getParentFile();
+        File configFile = new File(docParentFile, locAttribute);    
+        if (!configFile.exists()) {
+            configFile = new File(locAttribute);
+        }
         try {
             if (configFile.exists()) {
-                LibertyProjectsManager.getInstance().getWorkspaceFolder(docURIString).addConfigFile(configFile.getCanonicalPath());
+                LibertyProjectsManager.getInstance().getWorkspaceFolder(domDocument.getDocumentURI()).addConfigFile(configFile.getCanonicalPath());
             } else {
                 if (optString != null && required) {
                     DOMNode optNode = node.getAttributeNode("optional");
                     Range optRange = XMLPositionUtility.createRange(optNode.getStart(), optNode.getEnd(), domDocument);
-                    list.add(new Diagnostic(optRange, NOT_OPTIONAL_MESSAGE, 
+                    list.add(new Diagnostic(optRange, "The specified resource cannot be skipped. Check location value or set optional to true.", 
                             DiagnosticSeverity.Error, "liberty-lemminx", NOT_OPTIONAL_CODE));
                 }
-                list.add(new Diagnostic(range, MISSING_FILE_MESSAGE + configFile.getCanonicalPath(), 
+                list.add(new Diagnostic(range, "The resource at the specified location could not be found.", 
                         DiagnosticSeverity.Warning, "liberty-lemminx", MISSING_FILE_CODE));
             }
         } catch (IllegalArgumentException | IOException e) {
-            list.add(new Diagnostic(range, MISSING_FILE_MESSAGE + configFile.getAbsolutePath(), 
+            list.add(new Diagnostic(range, "The resource at the specified location could not be found.", 
                     DiagnosticSeverity.Warning, "liberty-lemminx-exception", MISSING_FILE_CODE));
         }
     }

--- a/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/LibertyDiagnosticParticipant.java
+++ b/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/LibertyDiagnosticParticipant.java
@@ -126,10 +126,10 @@ public class LibertyDiagnosticParticipant implements IDiagnosticsParticipant {
         }
 
         String optString = node.getAttribute("optional");
-        boolean required = optString == null ? false : optString.equals("false");
+        boolean required = optString == null ? true : optString.equals("false");
 
         File docParentFile = LibertyUtils.getDocumentAsFile(domDocument).getParentFile();
-        File configFile = new File(docParentFile, locAttribute);    
+        File configFile = new File(docParentFile, locAttribute);
         if (!configFile.exists()) {
             configFile = new File(locAttribute);
         }

--- a/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/LibertyExtension.java
+++ b/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/LibertyExtension.java
@@ -75,6 +75,7 @@ public class LibertyExtension implements IXMLExtension {
         xmlExtensionsRegistry.unregisterCompletionParticipant(completionParticipant);
         xmlExtensionsRegistry.unregisterHoverParticipant(hoverParticipant);
         xmlExtensionsRegistry.unregisterDiagnosticsParticipant(diagnosticsParticipant);
+        xmlExtensionsRegistry.unregisterCodeActionParticipant(codeActionsParticipant);
     }
 
     // Do save is called on startup with a Settings update

--- a/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/LibertyExtension.java
+++ b/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/LibertyExtension.java
@@ -12,6 +12,7 @@
 *******************************************************************************/
 package io.openliberty.tools.langserver.lemminx;
 
+import org.eclipse.lemminx.services.extensions.ICodeActionParticipant;
 import org.eclipse.lemminx.services.extensions.ICompletionParticipant;
 import org.eclipse.lemminx.services.extensions.IHoverParticipant;
 import org.eclipse.lemminx.services.extensions.IXMLExtension;
@@ -37,6 +38,7 @@ public class LibertyExtension implements IXMLExtension {
     private ICompletionParticipant completionParticipant;
     private IHoverParticipant hoverParticipant;
     private IDiagnosticsParticipant diagnosticsParticipant;
+    private ICodeActionParticipant codeActionsParticipant;
 
     @Override
     public void start(InitializeParams initializeParams, XMLExtensionsRegistry xmlExtensionsRegistry) {
@@ -59,6 +61,9 @@ public class LibertyExtension implements IXMLExtension {
 
         diagnosticsParticipant = new LibertyDiagnosticParticipant();
         xmlExtensionsRegistry.registerDiagnosticsParticipant(diagnosticsParticipant);
+
+        codeActionsParticipant = new LibertyCodeActionParticipant();
+        xmlExtensionsRegistry.registerCodeActionParticipant(codeActionsParticipant);
     }
 
     @Override

--- a/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/codeactions/AddAttribute.java
+++ b/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/codeactions/AddAttribute.java
@@ -1,0 +1,40 @@
+/*******************************************************************************
+* Copyright (c) 2022 IBM Corporation and others.
+*
+* This program and the accompanying materials are made available under the
+* terms of the Eclipse Public License v. 2.0 which is available at
+* http://www.eclipse.org/legal/epl-2.0.
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*     IBM Corporation - initial API and implementation
+*******************************************************************************/
+
+package io.openliberty.tools.langserver.lemminx.codeactions;
+
+import java.util.List;
+
+import org.eclipse.lemminx.commons.CodeActionFactory;
+import org.eclipse.lemminx.dom.DOMDocument;
+import org.eclipse.lemminx.services.extensions.ICodeActionParticipant;
+import org.eclipse.lemminx.services.extensions.IComponentProvider;
+import org.eclipse.lemminx.settings.SharedSettings;
+import org.eclipse.lsp4j.CodeAction;
+import org.eclipse.lsp4j.Diagnostic;
+import org.eclipse.lsp4j.Range;
+
+public class AddAttribute implements ICodeActionParticipant {
+
+    @Override
+    public void doCodeAction(Diagnostic diagnostic, Range range, DOMDocument document, List<CodeAction> codeActions,
+            SharedSettings sharedSettings, IComponentProvider componentProvider) {
+        try {
+            String title = "Add optional attribute and set to true.";
+            String replaceText = "optional=\"true\" ";
+            codeActions.add(CodeActionFactory.insert(title, diagnostic.getRange().getStart(), replaceText, document.getTextDocument(), diagnostic));
+        } catch (Exception e) {
+            // do nothing
+        }
+    }
+}

--- a/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/codeactions/CreateFile.java
+++ b/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/codeactions/CreateFile.java
@@ -15,6 +15,7 @@ package io.openliberty.tools.langserver.lemminx.codeactions;
 
 import java.io.File;
 import java.util.List;
+import java.util.logging.Logger;
 
 import org.eclipse.lemminx.commons.CodeActionFactory;
 import org.eclipse.lemminx.dom.DOMDocument;
@@ -25,9 +26,12 @@ import org.eclipse.lsp4j.CodeAction;
 import org.eclipse.lsp4j.Diagnostic;
 import org.eclipse.lsp4j.Range;
 
+import io.openliberty.tools.langserver.lemminx.LibertyExtension;
 import io.openliberty.tools.langserver.lemminx.util.LibertyUtils;
 
 public class CreateFile implements ICodeActionParticipant {
+    private static final Logger LOGGER = Logger.getLogger(LibertyExtension.class.getName());
+
     private static final String EMPTY_SERVER_CONFIG = "<server>" + System.lineSeparator() + "</server>";
 
     @Override
@@ -48,6 +52,7 @@ public class CreateFile implements ICodeActionParticipant {
             //     SERVER_TAGS_CONTENT, diagnostic));
         } catch (Exception e) {
             // BadLocationException not expected
+            LOGGER.warning("Could not generate code action for create file: " + e);
         }
     }
 }

--- a/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/codeactions/CreateFile.java
+++ b/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/codeactions/CreateFile.java
@@ -1,0 +1,58 @@
+/*******************************************************************************
+* Copyright (c) 2022 IBM Corporation and others.
+*
+* This program and the accompanying materials are made available under the
+* terms of the Eclipse Public License v. 2.0 which is available at
+* http://www.eclipse.org/legal/epl-2.0.
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*     IBM Corporation - initial API and implementation
+*******************************************************************************/
+
+package io.openliberty.tools.langserver.lemminx.codeactions;
+
+import java.io.File;
+import java.net.URI;
+import java.util.List;
+
+import org.eclipse.lemminx.commons.CodeActionFactory;
+import org.eclipse.lemminx.dom.DOMDocument;
+import org.eclipse.lemminx.dom.DOMNode;
+import org.eclipse.lemminx.services.extensions.ICodeActionParticipant;
+import org.eclipse.lemminx.services.extensions.IComponentProvider;
+import org.eclipse.lemminx.settings.SharedSettings;
+import org.eclipse.lsp4j.CodeAction;
+import org.eclipse.lsp4j.Diagnostic;
+import org.eclipse.lsp4j.Range;
+
+import io.openliberty.tools.langserver.lemminx.LibertyDiagnosticParticipant;
+
+public class CreateFile implements ICodeActionParticipant {
+    private static final String CREATE_CONFIG_FILE_TITLE = "Create missing config file with <server> tags included";
+    private static final String SERVER_TAGS_CONTENT = "<server>\n\n</server>";
+
+    @Override
+    public void doCodeAction(Diagnostic diagnostic, Range range, DOMDocument document, List<CodeAction> codeActions,
+            SharedSettings sharedSettings, IComponentProvider componentProvider) {
+        String fileURI;
+
+        if (diagnostic.getCode().getLeft().equals(LibertyDiagnosticParticipant.MISSING_FILE_CODE)) {
+            String message = diagnostic.getMessage();
+            fileURI = message.substring(message.indexOf("\n")+1);
+            codeActions.add(CodeActionFactory.createFile(CREATE_CONFIG_FILE_TITLE, fileURI, SERVER_TAGS_CONTENT, diagnostic));
+        } else {
+            try {
+                // attempt to extract location value from same node in Diagnostic range
+                String docURIString = document.getDocumentURI().replace(File.separator, "/");
+                DOMNode includeNode = document.findNodeAt(document.offsetAt(range.getEnd()));
+                fileURI = includeNode.getAttribute("location").replace(File.separator, "/");
+                fileURI = URI.create(docURIString.substring(0, docURIString.lastIndexOf("/")+1)).resolve(fileURI).normalize().toString();
+                codeActions.add(CodeActionFactory.createFile(CREATE_CONFIG_FILE_TITLE, fileURI, SERVER_TAGS_CONTENT, diagnostic));
+            } catch (Exception e) {
+                // do nothing
+            }
+        }
+    }
+}

--- a/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/codeactions/EditAttribute.java
+++ b/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/codeactions/EditAttribute.java
@@ -1,0 +1,30 @@
+package io.openliberty.tools.langserver.lemminx.codeactions;
+
+import java.util.List;
+
+import org.eclipse.lemminx.commons.CodeActionFactory;
+import org.eclipse.lemminx.dom.DOMDocument;
+import org.eclipse.lemminx.services.extensions.ICodeActionParticipant;
+import org.eclipse.lemminx.services.extensions.IComponentProvider;
+import org.eclipse.lemminx.settings.SharedSettings;
+import org.eclipse.lsp4j.CodeAction;
+import org.eclipse.lsp4j.Diagnostic;
+import org.eclipse.lsp4j.Range;
+
+public class EditAttribute implements ICodeActionParticipant {
+
+    @Override
+    public void doCodeAction(Diagnostic diagnostic, Range range, DOMDocument document, List<CodeAction> codeActions,
+            SharedSettings sharedSettings, IComponentProvider componentProvider) {
+        try {
+            String title = "Set optional attribute value from false to true";
+            String replaceText = "optional=\"true\"";
+            codeActions.add(CodeActionFactory.replace(title, range, replaceText, document.getTextDocument(), diagnostic));
+
+            // also build option to create file
+            new CreateFile().doCodeAction(diagnostic, range, document, codeActions, sharedSettings, componentProvider);
+        } catch (Exception e) {
+            // do nothing
+        }
+    }
+}

--- a/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/codeactions/EditAttribute.java
+++ b/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/codeactions/EditAttribute.java
@@ -17,9 +17,9 @@ public class EditAttribute implements ICodeActionParticipant {
     public void doCodeAction(Diagnostic diagnostic, Range range, DOMDocument document, List<CodeAction> codeActions,
             SharedSettings sharedSettings, IComponentProvider componentProvider) {
         try {
-            String title = "Set optional attribute value from false to true";
+            String title = "Change the optional attribute from false to true.";
             String replaceText = "optional=\"true\"";
-            codeActions.add(CodeActionFactory.replace(title, range, replaceText, document.getTextDocument(), diagnostic));
+            codeActions.add(CodeActionFactory.replace(title, diagnostic.getRange(), replaceText, document.getTextDocument(), diagnostic));
 
             // also build option to create file
             new CreateFile().doCodeAction(diagnostic, range, document, codeActions, sharedSettings, componentProvider);

--- a/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/codeactions/EditAttribute.java
+++ b/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/codeactions/EditAttribute.java
@@ -30,7 +30,7 @@ public class EditAttribute implements ICodeActionParticipant {
     public void doCodeAction(Diagnostic diagnostic, Range range, DOMDocument document, List<CodeAction> codeActions,
             SharedSettings sharedSettings, IComponentProvider componentProvider) {
         try {
-            String title = "Change the optional attribute from false to true.";
+            String title = "Set the optional attribute to true.";
             String replaceText = "optional=\"true\"";
             codeActions.add(CodeActionFactory.replace(title, diagnostic.getRange(), replaceText, document.getTextDocument(), diagnostic));
 

--- a/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/codeactions/EditAttribute.java
+++ b/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/codeactions/EditAttribute.java
@@ -1,3 +1,16 @@
+/*******************************************************************************
+* Copyright (c) 2022 IBM Corporation and others.
+*
+* This program and the accompanying materials are made available under the
+* terms of the Eclipse Public License v. 2.0 which is available at
+* http://www.eclipse.org/legal/epl-2.0.
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*     IBM Corporation - initial API and implementation
+*******************************************************************************/
+
 package io.openliberty.tools.langserver.lemminx.codeactions;
 
 import java.util.List;

--- a/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/services/LibertyWorkspace.java
+++ b/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/services/LibertyWorkspace.java
@@ -111,7 +111,7 @@ public class LibertyWorkspace {
             Matcher m = Pattern.compile(regex).matcher(content);
             while (m.find()) {
                 // m.group(0) contains whole include element, m.group(1) contains only location value
-                configFiles.add(filePath.getParent().resolve(m.group(1)).toFile().getCanonicalPath());
+                configFiles.add(new File(filePath.getParent().toFile(), m.group(1)).getCanonicalPath());
             }
         } catch (IOException e) {
             // specified config resources file does not exist

--- a/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/util/LibertyUtils.java
+++ b/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/util/LibertyUtils.java
@@ -12,8 +12,10 @@
 *******************************************************************************/
 package io.openliberty.tools.langserver.lemminx.util;
 
+import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.net.URI;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -65,6 +67,15 @@ public class LibertyUtils {
 
     public static boolean isConfigXMLFile(DOMDocument file) {
         return isConfigXMLFile(file.getDocumentURI());
+    }
+
+    // Convenience methods
+    public static File getDocumentAsFile(DOMDocument document) {
+        return new File(getDocumentAsUri(document));
+    }
+
+    public static URI getDocumentAsUri(DOMDocument document) {
+        return URI.create(document.getDocumentURI());
     }
 
     /**
@@ -240,5 +251,4 @@ public class LibertyUtils {
             LOGGER.warning("Unable to watch properties file(s): " + e.toString());
         }
     }
-
 }

--- a/lemminx-liberty/src/test/java/io/openliberty/LibertyDiagnosticTest.java
+++ b/lemminx-liberty/src/test/java/io/openliberty/LibertyDiagnosticTest.java
@@ -80,12 +80,14 @@ public class LibertyDiagnosticTest {
         String serverXML = String.join(newLine, //
                 "<server description=\"default server\">", //
                 "    <include optional=\"true\" location=\"./empty_server.xml\"/>", //
-                "    <include optional=\"false\" location=\"MISSING FILE\"/>", //
+                "    <include optional=\"true\" location=\"/empty_server.xml\"/>", //
+                "    <include optional=\"true\" location=\"MISSING FILE\"/>", //
                 "    <include", //
                 "            optional=\"true\" location=\"MULTI LINER\"/>", //
                 "    <include optional=\"false\" location=\"MISSING FILE.xml\"/>", //
                 "</server>"
         );
+        
         // Diagnostic location1 = new Diagnostic();
         File serverXMLFile = new File("src/test/resources/server.xml");
         assertFalse(serverXMLFile.exists());
@@ -93,19 +95,24 @@ public class LibertyDiagnosticTest {
         assertTrue(new File("src/test/resources/empty_server.xml").exists());
 
         Diagnostic location2 = new Diagnostic();
-        location2.setRange(r(2, 30, 2, 53));
-        location2.setMessage("The specified file is not an XML file.");
+        location2.setRange(r(3, 29, 3, 52));
+        location2.setMessage("The specified resource is not an XML file.");
 
         Diagnostic location3 = new Diagnostic();
-        location3.setRange(r(4, 28, 4, 50));
-        location3.setMessage("The specified file is not an XML file.");
+        location3.setRange(r(5, 28, 5, 50));
+        location3.setMessage("The specified resource is not an XML file.");
         
         Diagnostic location4 = new Diagnostic();
-        location4.setRange(r(5, 30, 5, 57));
-        location4.setMessage("The file at the specified location could not be found.");
+        location4.setRange(r(6, 13, 6, 29));
+        location4.setCode("not_optional");
+        location4.setMessage("The specified resource cannot be skipped. Check location value or set optional to true.");
 
+        Diagnostic location5 = new Diagnostic();
+        location5.setRange(r(6, 30, 6, 57));
+        location5.setCode("missing_file");
+        location5.setMessage("The resource at the specified location could not be found.");
 
-        XMLAssert.testDiagnosticsFor(serverXML, null, null, serverXMLFile.toURI().toString(), location2, location3, location4);
+        XMLAssert.testDiagnosticsFor(serverXML, null, null, serverXMLFile.toURI().toString(), location2, location3, location4, location5);
 
         assertTrue(LibertyProjectsManager.getInstance().getLibertyWorkspaceFolders().get(0)
                 .hasConfigFile(new File("src/test/resources/empty_server.xml").getCanonicalPath()));

--- a/lemminx-liberty/src/test/java/io/openliberty/LibertyDiagnosticTest.java
+++ b/lemminx-liberty/src/test/java/io/openliberty/LibertyDiagnosticTest.java
@@ -85,6 +85,7 @@ public class LibertyDiagnosticTest {
                 "    <include", //
                 "            optional=\"true\" location=\"MULTI LINER\"/>", //
                 "    <include optional=\"false\" location=\"MISSING FILE.xml\"/>", //
+                "    <include location=\"MISSING FILE.xml\"/>", //
                 "</server>"
         );
         
@@ -94,25 +95,31 @@ public class LibertyDiagnosticTest {
         // Diagnostic will not be made if found
         assertTrue(new File("src/test/resources/empty_server.xml").exists());
 
-        Diagnostic location2 = new Diagnostic();
-        location2.setRange(r(3, 29, 3, 52));
-        location2.setMessage("The specified resource is not an XML file.");
+        Diagnostic not_xml = new Diagnostic();
+        not_xml.setRange(r(3, 29, 3, 52));
+        not_xml.setMessage("The specified resource is not an XML file.");
 
-        Diagnostic location3 = new Diagnostic();
-        location3.setRange(r(5, 28, 5, 50));
-        location3.setMessage("The specified resource is not an XML file.");
+        Diagnostic multi_liner = new Diagnostic();
+        multi_liner.setRange(r(5, 28, 5, 50));
+        multi_liner.setMessage("The specified resource is not an XML file.");
         
-        Diagnostic location4 = new Diagnostic();
-        location4.setRange(r(6, 13, 6, 29));
-        location4.setCode("not_optional");
-        location4.setMessage("The specified resource cannot be skipped. Check location value or set optional to true.");
+        Diagnostic not_optional = new Diagnostic();
+        not_optional.setRange(r(6, 13, 6, 29));
+        not_optional.setCode("not_optional");
+        not_optional.setMessage("The specified resource cannot be skipped. Check location value or set optional to true.");
 
-        Diagnostic location5 = new Diagnostic();
-        location5.setRange(r(6, 30, 6, 57));
-        location5.setCode("missing_file");
-        location5.setMessage("The resource at the specified location could not be found.");
+        Diagnostic missing_xml = new Diagnostic();
+        missing_xml.setRange(r(6, 30, 6, 57));
+        missing_xml.setCode("missing_file");
+        missing_xml.setMessage("The resource at the specified location could not be found.");
 
-        XMLAssert.testDiagnosticsFor(serverXML, null, null, serverXMLFile.toURI().toString(), location2, location3, location4, location5);
+        Diagnostic optional_not_defined = new Diagnostic();
+        optional_not_defined.setRange(r(7, 13, 7, 40));
+        optional_not_defined.setCode("missing_file");
+        optional_not_defined.setMessage("The resource at the specified location could not be found.");
+
+        XMLAssert.testDiagnosticsFor(serverXML, null, null, serverXMLFile.toURI().toString(), 
+                not_xml, multi_liner, not_optional, missing_xml, optional_not_defined);
 
         assertTrue(LibertyProjectsManager.getInstance().getLibertyWorkspaceFolders().get(0)
                 .hasConfigFile(new File("src/test/resources/empty_server.xml").getCanonicalPath()));

--- a/lemminx-liberty/src/test/java/io/openliberty/LibertyDiagnosticTest.java
+++ b/lemminx-liberty/src/test/java/io/openliberty/LibertyDiagnosticTest.java
@@ -102,7 +102,7 @@ public class LibertyDiagnosticTest {
         Diagnostic multi_liner = new Diagnostic();
         multi_liner.setRange(r(5, 28, 5, 50));
         multi_liner.setMessage("The specified resource is not an XML file.");
-        
+
         Diagnostic not_optional = new Diagnostic();
         not_optional.setRange(r(6, 13, 6, 29));
         not_optional.setCode("not_optional");
@@ -115,11 +115,17 @@ public class LibertyDiagnosticTest {
 
         Diagnostic optional_not_defined = new Diagnostic();
         optional_not_defined.setRange(r(7, 13, 7, 40));
-        optional_not_defined.setCode("missing_file");
-        optional_not_defined.setMessage("The resource at the specified location could not be found.");
+        optional_not_defined.setCode("implicit_not_optional");
+        optional_not_defined.setMessage("The specified resource cannot be skipped. Check location value or add optional attribute.");
+
+        Diagnostic missing_xml2 = new Diagnostic();
+        missing_xml2.setRange(r(7, 13, 7, 40));
+        missing_xml2.setCode("missing_file");
+        missing_xml2.setMessage("The resource at the specified location could not be found.");
+
 
         XMLAssert.testDiagnosticsFor(serverXML, null, null, serverXMLFile.toURI().toString(), 
-                not_xml, multi_liner, not_optional, missing_xml, optional_not_defined);
+                not_xml, multi_liner, not_optional, missing_xml, optional_not_defined, missing_xml2);
 
         assertTrue(LibertyProjectsManager.getInstance().getLibertyWorkspaceFolders().get(0)
                 .hasConfigFile(new File("src/test/resources/empty_server.xml").getCanonicalPath()));


### PR DESCRIPTION
- [x] Code Actions

- Initialize new LibertyCodeActionParticipant in extension
- Construct map of error code to ICodeActionParticipant
- Provide CreateFile and EditAttribute as basic quick fixes
  - CreateFile will peek into the `<include>` node, grab the `location` attribute, and attempt to create a relative file from the current config file.

![create file](https://user-images.githubusercontent.com/8934136/168695302-5ef63d08-9f25-4a11-9532-c7c6eb4b263b.gif)

  - EditAttribute will replace the text from the diagnostic range to `optional="true"`
  
![Peek 2022-05-16 17-49](https://user-images.githubusercontent.com/8934136/168695201-f2f8958c-a58a-4bfe-8232-763d0771564e.gif)

  - AddAttribute will insert `optional="true"` before `location`

![add_attribute](https://user-images.githubusercontent.com/8934136/170770083-25a607a2-1e31-465e-ba65-fe55ad3f3b37.gif)



- [x] Config File Changes

- Checks relative path, then absolute path, with server config dir check in part of a different call.
- URL content verification to be determined. So for this PR, diagnostic warning is muted based on heuristic if `location` attribute starts with `http`
- Similarly, env vars haven't be resolved, so muted with heuristic of containing `$`

- New Diagnostic message for when resource is not found and optional is set to false
![image](https://user-images.githubusercontent.com/8934136/167892411-0ea743fe-03f2-4b64-aba2-136075391b2f.png)
and two quick fix solutions for either creating an empty server config file or changing optional value
![image](https://user-images.githubusercontent.com/8934136/168693826-1b467e7b-ccdd-4cce-b05a-6c19f85a5a23.png)

- [x] OS compatibility

- Empty server config content gets initialized with `"<server>" + System.lineSeparator() + "</server>"`
- Relative path for new file is obtained from document URI as base, and resolved.




