### PR TITLE
upgrade lsp4j; patch gson vulnerability

### DIFF
--- a/liberty-ls/pom.xml
+++ b/liberty-ls/pom.xml
@@ -14,7 +14,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
-    <lsp4j.version>0.9.0</lsp4j.version>
+    <lsp4j.version>0.14.0</lsp4j.version>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/8934136/172226043-caff0589-e69e-452f-8e1e-b7fb5998adcf.png)

Screenshot demonstrates Whitesource view. They're autoclosed in the screenshot having tested the library upgrade

**Some source details provided from expanding the issue:**
<p>Gson JSON library</p>
<p>Library home page: <a href="https://github.com/google/gson">https://github.com/google/gson</a></p>
<p>Path to dependency file: /liberty-ls/pom.xml</p>
<p>Path to vulnerable library: /home/wss-scanner/.m2/repository/com/google/code/gson/gson/2.8.2/gson-2.8.2.jar</p>
<p>

Dependency Hierarchy:
  - org.eclipse.lsp4j.jsonrpc-0.9.0.jar (Root Library)
    - :x: **gson-2.8.2.jar** (Vulnerable Library)