### PR TITLE
Rearrange values for default. Preselect default value for completion

### DIFF
--- a/liberty-ls/src/main/java/io/openliberty/tools/langserver/model/propertiesfile/PropertiesKeyInstance.java
+++ b/liberty-ls/src/main/java/io/openliberty/tools/langserver/model/propertiesfile/PropertiesKeyInstance.java
@@ -66,6 +66,11 @@ public class PropertiesKeyInstance {
     public List<CompletionItem> getValidValues() {
         List<String> values = ServerPropertyValues.getValidValues(textDocumentItem, propertyKey);
         List<CompletionItem> results = values.stream().map(s -> new CompletionItem(s)).collect(Collectors.toList());
+        // Preselect the default.
+        // This uses the first item in the List as default. 
+        // (Check ServerPropertyValues.java) Currently sorted to have confirmed/sensible values as default.
+        CompletionItem first = results.get(0);
+        first.setPreselect(true);
         return results;
     }
 

--- a/liberty-ls/src/main/java/io/openliberty/tools/langserver/utils/ServerPropertyValues.java
+++ b/liberty-ls/src/main/java/io/openliberty/tools/langserver/utils/ServerPropertyValues.java
@@ -26,24 +26,24 @@ public class ServerPropertyValues {
     private final static List<String> YES_NO_VALUES = Arrays.asList("y", "n");
     
     private static HashMap<String, List<String>> validServerValues = new HashMap<String, List<String>>() {{
-        put("WLP_DEBUG_SUSPEND", YES_NO_VALUES);
-        put("WLP_DEBUG_REMOTE", YES_NO_VALUES);
+        put("WLP_DEBUG_SUSPEND", YES_NO_VALUES); // default yes
+        put("WLP_DEBUG_REMOTE", YES_NO_VALUES); // default undefined/disabled, so it's pointless selecting no
         
-        put("WLP_LOGGING_CONSOLE_FORMAT", Arrays.asList("dev", "simple", "json"));
-        put("WLP_LOGGING_CONSOLE_LOGLEVEL", Arrays.asList("INFO", "AUDIT", "WARNING", "ERROR", "OFF"));
-        put("WLP_LOGGING_CONSOLE_SOURCE", LOGGING_SOURCE_VALUES);
-        put("WLP_LOGGING_MESSAGE_FORMAT", Arrays.asList("simple", "json"));
-        put("WLP_LOGGING_MESSAGE_SOURCE", LOGGING_SOURCE_VALUES);
-        put("WLP_LOGGING_APPS_WRITE_JSON", BOOLEAN_VALUES);
+        put("WLP_LOGGING_CONSOLE_FORMAT", Arrays.asList("DEV", "SIMPLE", "JSON", "TBASIC")); // default "DEV"
+        put("WLP_LOGGING_CONSOLE_LOGLEVEL", Arrays.asList("AUDIT", "INFO", "WARNING", "ERROR", "OFF")); // default "AUDIT"
+        put("WLP_LOGGING_CONSOLE_SOURCE", LOGGING_SOURCE_VALUES); //default "message"
+        put("WLP_LOGGING_MESSAGE_FORMAT", Arrays.asList("SIMPLE", "JSON", "TBASIC")); // default "SIMPLE"
+        put("WLP_LOGGING_MESSAGE_SOURCE", LOGGING_SOURCE_VALUES); //default "message"
+        put("WLP_LOGGING_APPS_WRITE_JSON", BOOLEAN_VALUES); //unknown default
     }};
 
     private static HashMap<String, List<String>> validBootstrapValues = new HashMap<String, List<String>>() {{
-        put("com.ibm.ws.logging.copy.system.streams", BOOLEAN_VALUES);
-        put("com.ibm.ws.logging.newLogsOnStart", BOOLEAN_VALUES);
-        put("com.ibm.ws.logging.isoDateFormat", BOOLEAN_VALUES);
-        put("com.ibm.ws.logging.trace.format", Arrays.asList("ENHANCED", "BASIC", "ADVANCED"));
+        put("com.ibm.ws.logging.copy.system.streams", BOOLEAN_VALUES); // default true
+        put("com.ibm.ws.logging.newLogsOnStart", BOOLEAN_VALUES); // default true
+        put("com.ibm.ws.logging.isoDateFormat", Arrays.asList("false", "true")); // default false
+        put("com.ibm.ws.logging.trace.format", Arrays.asList("ENHANCED", "BASIC", "TBASIC", "ADVANCED")); // default "ENHANCED"
         put("websphere.log.provider", Arrays.asList("binaryLogging-1.0"));
-        put("com.ibm.hpel.log.bufferingEnabled", BOOLEAN_VALUES);
+        put("com.ibm.hpel.log.bufferingEnabled", BOOLEAN_VALUES); // default undefined/disabled
         EquivalentProperties.getBootstrapKeys().forEach(
             bskey -> {
                 String serverEnvEquivalent = EquivalentProperties.getEquivalentProperty(bskey);

--- a/liberty-ls/src/main/java/io/openliberty/tools/langserver/utils/ServerPropertyValues.java
+++ b/liberty-ls/src/main/java/io/openliberty/tools/langserver/utils/ServerPropertyValues.java
@@ -23,6 +23,7 @@ import io.openliberty.tools.langserver.ls.LibertyTextDocument;
 public class ServerPropertyValues {
     private final static List<String> LOGGING_SOURCE_VALUES = Arrays.asList("message", "trace", "accessLog", "ffdc", "audit");
     private final static List<String> BOOLEAN_VALUES = Arrays.asList("true", "false");
+    private final static List<String> BOOLEAN_VALUES_REVERSE = Arrays.asList("false", "true");
     private final static List<String> YES_NO_VALUES = Arrays.asList("y", "n");
     
     private static HashMap<String, List<String>> validServerValues = new HashMap<String, List<String>>() {{
@@ -34,16 +35,16 @@ public class ServerPropertyValues {
         put("WLP_LOGGING_CONSOLE_SOURCE", LOGGING_SOURCE_VALUES); //default "message"
         put("WLP_LOGGING_MESSAGE_FORMAT", Arrays.asList("SIMPLE", "JSON", "TBASIC")); // default "SIMPLE"
         put("WLP_LOGGING_MESSAGE_SOURCE", LOGGING_SOURCE_VALUES); //default "message"
-        put("WLP_LOGGING_APPS_WRITE_JSON", BOOLEAN_VALUES); //unknown default
+        put("WLP_LOGGING_APPS_WRITE_JSON", BOOLEAN_VALUES_REVERSE); //default false
     }};
 
     private static HashMap<String, List<String>> validBootstrapValues = new HashMap<String, List<String>>() {{
         put("com.ibm.ws.logging.copy.system.streams", BOOLEAN_VALUES); // default true
         put("com.ibm.ws.logging.newLogsOnStart", BOOLEAN_VALUES); // default true
-        put("com.ibm.ws.logging.isoDateFormat", Arrays.asList("false", "true")); // default false
+        put("com.ibm.ws.logging.isoDateFormat", BOOLEAN_VALUES_REVERSE); // default false
         put("com.ibm.ws.logging.trace.format", Arrays.asList("ENHANCED", "BASIC", "TBASIC", "ADVANCED")); // default "ENHANCED"
         put("websphere.log.provider", Arrays.asList("binaryLogging-1.0"));
-        put("com.ibm.hpel.log.bufferingEnabled", BOOLEAN_VALUES); // default undefined/disabled
+        put("com.ibm.hpel.log.bufferingEnabled", BOOLEAN_VALUES); // default true
         EquivalentProperties.getBootstrapKeys().forEach(
             bskey -> {
                 String serverEnvEquivalent = EquivalentProperties.getEquivalentProperty(bskey);

--- a/liberty-ls/src/main/java/io/openliberty/tools/langserver/utils/ServerPropertyValues.java
+++ b/liberty-ls/src/main/java/io/openliberty/tools/langserver/utils/ServerPropertyValues.java
@@ -10,7 +10,6 @@
 package io.openliberty.tools.langserver.utils;
 
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -22,29 +21,29 @@ import io.openliberty.tools.langserver.ls.LibertyTextDocument;
  */
 public class ServerPropertyValues {
     private final static List<String> LOGGING_SOURCE_VALUES = Arrays.asList("message", "trace", "accessLog", "ffdc", "audit");
-    private final static List<String> BOOLEAN_VALUES = Arrays.asList("true", "false");
-    private final static List<String> BOOLEAN_VALUES_REVERSE = Arrays.asList("false", "true");
+    private final static List<String> BOOLEAN_VALUES_DEFAULT_TRUE = Arrays.asList("true", "false");
+    private final static List<String> BOOLEAN_VALUES_DEFAULT_FALSE = Arrays.asList("false", "true");
     private final static List<String> YES_NO_VALUES = Arrays.asList("y", "n");
     
     private static HashMap<String, List<String>> validServerValues = new HashMap<String, List<String>>() {{
         put("WLP_DEBUG_SUSPEND", YES_NO_VALUES); // default yes
-        put("WLP_DEBUG_REMOTE", YES_NO_VALUES); // default undefined/disabled, so it's pointless selecting no
+        put("WLP_DEBUG_REMOTE", YES_NO_VALUES); // default undefined/disabled, but will preselect "y" to enable
         
         put("WLP_LOGGING_CONSOLE_FORMAT", Arrays.asList("DEV", "SIMPLE", "JSON", "TBASIC")); // default "DEV"
         put("WLP_LOGGING_CONSOLE_LOGLEVEL", Arrays.asList("AUDIT", "INFO", "WARNING", "ERROR", "OFF")); // default "AUDIT"
         put("WLP_LOGGING_CONSOLE_SOURCE", LOGGING_SOURCE_VALUES); //default "message"
         put("WLP_LOGGING_MESSAGE_FORMAT", Arrays.asList("SIMPLE", "JSON", "TBASIC")); // default "SIMPLE"
         put("WLP_LOGGING_MESSAGE_SOURCE", LOGGING_SOURCE_VALUES); //default "message"
-        put("WLP_LOGGING_APPS_WRITE_JSON", BOOLEAN_VALUES_REVERSE); //default false
+        put("WLP_LOGGING_APPS_WRITE_JSON", BOOLEAN_VALUES_DEFAULT_FALSE); //default false
     }};
 
     private static HashMap<String, List<String>> validBootstrapValues = new HashMap<String, List<String>>() {{
-        put("com.ibm.ws.logging.copy.system.streams", BOOLEAN_VALUES); // default true
-        put("com.ibm.ws.logging.newLogsOnStart", BOOLEAN_VALUES); // default true
-        put("com.ibm.ws.logging.isoDateFormat", BOOLEAN_VALUES_REVERSE); // default false
+        put("com.ibm.ws.logging.copy.system.streams", BOOLEAN_VALUES_DEFAULT_TRUE); // default true
+        put("com.ibm.ws.logging.newLogsOnStart", BOOLEAN_VALUES_DEFAULT_TRUE); // default true
+        put("com.ibm.ws.logging.isoDateFormat", BOOLEAN_VALUES_DEFAULT_FALSE); // default false
         put("com.ibm.ws.logging.trace.format", Arrays.asList("ENHANCED", "BASIC", "TBASIC", "ADVANCED")); // default "ENHANCED"
         put("websphere.log.provider", Arrays.asList("binaryLogging-1.0"));
-        put("com.ibm.hpel.log.bufferingEnabled", BOOLEAN_VALUES); // default true
+        put("com.ibm.hpel.log.bufferingEnabled", BOOLEAN_VALUES_DEFAULT_TRUE); // default true
         EquivalentProperties.getBootstrapKeys().forEach(
             bskey -> {
                 String serverEnvEquivalent = EquivalentProperties.getEquivalentProperty(bskey);


### PR DESCRIPTION
Also added `TBASIC` as an option for message formats, according to [OpenLiberty docs](https://openliberty.io/docs/latest/log-trace-configuration.html) and [WAS Libertydocs](https://www.ibm.com/docs/en/was-liberty/base?topic=SSEQTP_liberty%2Fcom.ibm.websphere.liberty.autogen.nd.doc%2Fae%2Frwlp_config_logging.html)