### PR TITLE
devc mode schema generation

### DIFF
--- a/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/LibertyXSDURIResolver.java
+++ b/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/LibertyXSDURIResolver.java
@@ -79,7 +79,7 @@ public class LibertyXSDURIResolver implements URIResolverExtension, IExternalGra
                             //Generate schema file
                             serverSchemaUri = generateServerSchemaXsd(libertyWorkspace, schemaGenJarPath);
                         }
-                    } else if (libertyWorkspace.hasRunningContainer()) {
+                    } else if (libertyWorkspace.isContainerAlive()) {
                         DockerService docker = DockerService.getInstance();
                         serverSchemaUri = docker.generateServerSchemaXsdFromContainer(libertyWorkspace);
                     }

--- a/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/LibertyXSDURIResolver.java
+++ b/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/LibertyXSDURIResolver.java
@@ -26,137 +26,142 @@ import org.eclipse.lemminx.uriresolver.IExternalGrammarLocationProvider;
 import org.eclipse.lemminx.uriresolver.CacheResourcesManager.ResourceToDeploy;
 import org.eclipse.lemminx.uriresolver.URIResolverExtension;
 
+import io.openliberty.tools.langserver.lemminx.services.DockerService;
 import io.openliberty.tools.langserver.lemminx.services.LibertyProjectsManager;
 import io.openliberty.tools.langserver.lemminx.services.LibertyWorkspace;
 import io.openliberty.tools.langserver.lemminx.util.LibertyUtils;
 
 public class LibertyXSDURIResolver implements URIResolverExtension, IExternalGrammarLocationProvider {
-  private static final Logger LOGGER = Logger.getLogger(LibertyXSDURIResolver.class.getName());
+    private static final Logger LOGGER = Logger.getLogger(LibertyXSDURIResolver.class.getName());
 
-  private static final String XSD_RESOURCE_URL = "https://github.com/OpenLiberty/liberty-language-server/blob/master/lemminx-liberty/src/main/resources/schema/xsd/liberty/server.xsd";
-  private static final String XSD_CLASSPATH_LOCATION = "/schema/xsd/liberty/server.xsd";
+    private static final String XSD_RESOURCE_URL = "https://github.com/OpenLiberty/liberty-language-server/blob/master/lemminx-liberty/src/main/resources/schema/xsd/liberty/server.xsd";
+    private static final String XSD_CLASSPATH_LOCATION = "/schema/xsd/liberty/server.xsd";
 
-  /**
-   * SERVER_XSD_RESOURCE is the server.xsd that is located at `/schema/server.xsd`
-   * that should be deployed (copied) to the .lemminx cache. The resourceURI is
-   * used by lemmix determine the path to store the file in the cache. So for
-   * server.xsd it takes the resource located at `/schema/server.xsd` and deploys
-   * it to:
-   * ~/.lemminx/cache/https/github.com/OpenLiberty/liberty-language-server/master/lemminx-liberty/src/main/resources/schema/server.xsd
-   * 
-   * Declared public to be used by tests
-   */
-  public static final ResourceToDeploy SERVER_XSD_RESOURCE = new ResourceToDeploy(XSD_RESOURCE_URL,
-      XSD_CLASSPATH_LOCATION);
+    /**
+     * SERVER_XSD_RESOURCE is the server.xsd that is located at `/schema/server.xsd`
+     * that should be deployed (copied) to the .lemminx cache. The resourceURI is
+     * used by lemmix determine the path to store the file in the cache. So for
+     * server.xsd it takes the resource located at `/schema/server.xsd` and deploys
+     * it to:
+     * ~/.lemminx/cache/https/github.com/OpenLiberty/liberty-language-server/master/lemminx-liberty/src/main/resources/schema/server.xsd
+     * 
+     * Declared public to be used by tests
+     */
+    public static final ResourceToDeploy SERVER_XSD_RESOURCE = new ResourceToDeploy(XSD_RESOURCE_URL,
+            XSD_CLASSPATH_LOCATION);
 
-  /**
-   * Will return an existing xsd file or generate one from a Liberty installation if ones exists
-   * 
-   * @param baseLocation
-   * @param publicId
-   * @param systemId
-   * 
-   * @return Path to schema xsd resource
-   */
-  public String resolve(String baseLocation, String publicId, String systemId) {
-    if (LibertyUtils.isConfigXMLFile(baseLocation)) {
-      try {
-        String serverXMLUri = URI.create(baseLocation).toString();
-        LibertyWorkspace libertyWorkspace = LibertyProjectsManager.getInstance().getWorkspaceFolder(serverXMLUri);
+    /**
+     * Will return an existing xsd file or generate one from a Liberty installation if ones exists
+     * 
+     * @param baseLocation
+     * @param publicId
+     * @param systemId
+     * 
+     * @return Path to schema xsd resource as URI.toString()
+     */
+    public String resolve(String baseLocation, String publicId, String systemId) {
+        if (LibertyUtils.isConfigXMLFile(baseLocation)) {
+            try {
+                String serverXMLUri = URI.create(baseLocation).toString();
+                LibertyWorkspace libertyWorkspace = LibertyProjectsManager.getInstance().getWorkspaceFolder(serverXMLUri);
 
-        if (libertyWorkspace != null) {
-          //Set workspace properties if not set 
-          LibertyUtils.getVersion(serverXMLUri);
-          LibertyUtils.getRuntimeInfo(serverXMLUri);
+                if (libertyWorkspace != null) {
+                    //Set workspace properties if not set 
+                    LibertyUtils.getVersion(serverXMLUri);
+                    LibertyUtils.getRuntimeInfo(serverXMLUri);
 
-          //Check workspace for Liberty installation and generate schema.xsd file
-          //Return schema URI as String, otherwise use cached schema.xsd file
-          if (libertyWorkspace.isLibertyInstalled()) {
-            Path schemaGenJarPath = LibertyUtils.findFileInWorkspace(libertyWorkspace, Paths.get("bin", "tools", "ws-schemagen.jar"));
-            if (schemaGenJarPath != null) {
-              //Generate schema file
-              String serverSchemaUri = generateServerSchemaXsd(libertyWorkspace, schemaGenJarPath);
-              if (serverSchemaUri != null && !serverSchemaUri.isEmpty()) {
-                return serverSchemaUri;
-              }
+                    //Check workspace for Liberty installation and generate schema.xsd file
+                    //Return schema URI as String, otherwise use cached schema.xsd file
+                    String serverSchemaUri = null;
+                    if (libertyWorkspace.isLibertyInstalled()) {
+                        Path schemaGenJarPath = LibertyUtils.findFileInWorkspace(libertyWorkspace, Paths.get("bin", "tools", "ws-schemagen.jar"));
+                        if (schemaGenJarPath != null) {
+                            //Generate schema file
+                            serverSchemaUri = generateServerSchemaXsd(libertyWorkspace, schemaGenJarPath);
+                        }
+                    } else if (libertyWorkspace.hasRunningContainer()) {
+                        DockerService docker = DockerService.getInstance();
+                        serverSchemaUri = docker.generateServerSchemaXsdFromContainer(libertyWorkspace);
+                    }
+                    if (serverSchemaUri != null && !serverSchemaUri.isEmpty()) {
+                        return serverSchemaUri;
+                    }
+                }
+                Path serverXSDFile = CacheResourcesManager.getResourceCachePath(SERVER_XSD_RESOURCE);
+                LOGGER.info("Using cached Liberty schema file located at: " + serverXSDFile.toString());
+                return serverXSDFile.toUri().toString();
+            } catch (Exception e) {
+                LOGGER.severe("Error: Unable to deploy server.xsd to lemminx cache.");
+                e.printStackTrace();
             }
-          }
         }
-        Path serverXSDFile = CacheResourcesManager.getResourceCachePath(SERVER_XSD_RESOURCE);
-        LOGGER.info("Using cached Liberty schema file located at: " + serverXSDFile.toString());
-        return serverXSDFile.toUri().toString();
-      } catch (Exception e) {
-        LOGGER.severe("Error: Unable to deploy server.xsd to lemminx cache.");
-        e.printStackTrace();
-      }
-    }
-    return null;
-  }
-
-  @Override
-  public Map<String, String> getExternalGrammarLocation(URI fileURI) {
-    String xsdFile = resolve(fileURI.toString(), null, null);
-    if (xsdFile == null) {
-      return null;
-    }
-
-    Map<String, String> externalGrammar = new HashMap<>();
-    externalGrammar.put(IExternalGrammarLocationProvider.NO_NAMESPACE_SCHEMA_LOCATION, xsdFile);
-    return externalGrammar;
-  }
-
-  /**
-   * Generate the schema file for a LibertyWorkspace using the ws-schemagen.jar in the corresponding Liberty installation
-   * @param libertyWorkspace
-   * @param schemaGenJarPath
-   * @return Path to generated schema file.
-   */
-  private String generateServerSchemaXsd(LibertyWorkspace libertyWorkspace, Path schemaGenJarPath) {
-    //java -jar path/to/ws-schemagen.jar path/to/workspace/.libertyls/libertySchema.xsd
-    File tempDir = LibertyUtils.getTempDir(libertyWorkspace.getWorkspaceURI().toString());
-
-    //If tempDir is null, issue a warning for the current LibertyWorkspace URI and use the default cached schema file
-    if (tempDir == null) {
-      LOGGER.warning("Could not create a temporary directory for generating the schema file. The cached schema file will be used for the current workspace: " + libertyWorkspace.getWorkspaceString());
-      return null;
-    }
-
-    //TODO: (?) Add subfolders to tempDir: schema/xsd/liberty/server.xsd
-    File xsdDestFile = new File(tempDir, "server.xsd");
-    if (libertyWorkspace.getLibertyVersion()!= null && !libertyWorkspace.getLibertyVersion().isEmpty() &&
-        libertyWorkspace.getLibertyRuntime()!= null && !libertyWorkspace.getLibertyRuntime().isEmpty()) {
-      xsdDestFile = new File(tempDir, libertyWorkspace.getLibertyRuntime() + "-" + libertyWorkspace.getLibertyVersion() + ".xsd");
-    }
-
-    if (!xsdDestFile.exists()) {
-      try {
-        LOGGER.info("Generating schema file from: " + schemaGenJarPath.toString());
-        String xsdDestPath = xsdDestFile.getCanonicalPath();
-  
-        LOGGER.info("Generating schema file at: " + xsdDestPath);
-  
-        ProcessBuilder pb = new ProcessBuilder("java", "-jar", schemaGenJarPath.toAbsolutePath().toString(), xsdDestPath); //Add locale param here
-        pb.directory(tempDir);
-        pb.redirectErrorStream(true);
-        pb.redirectOutput(new File(tempDir, "schemagen.log"));
-  
-        Process proc = pb.start();
-        if (!proc.waitFor(30, TimeUnit.SECONDS)) {
-          proc.destroy();
-          LOGGER.warning("Exceeded 30 second timeout during schema file generation. Using cached schema.xsd file.");
-          return null;
-        }
-
-        LOGGER.info("Caching schema file with URI: " + xsdDestFile.toURI().toString());
-      } catch (Exception e) {
-        LOGGER.warning(e.getMessage());
-        LOGGER.warning("Due to an exception during schema file generation, a cached schema file will be used.");
         return null;
-      }
     }
 
-    LOGGER.info("Using schema file at: " + xsdDestFile.toURI().toString());
-    return xsdDestFile.toURI().toString();
-  }
+    @Override
+    public Map<String, String> getExternalGrammarLocation(URI fileURI) {
+        String xsdFile = resolve(fileURI.toString(), null, null);
+        if (xsdFile == null) {
+            return null;
+        }
+
+        Map<String, String> externalGrammar = new HashMap<>();
+        externalGrammar.put(IExternalGrammarLocationProvider.NO_NAMESPACE_SCHEMA_LOCATION, xsdFile);
+        return externalGrammar;
+    }
+
+    /**
+     * Generate the schema file for a LibertyWorkspace using the ws-schemagen.jar in the corresponding Liberty installation
+     * @param libertyWorkspace
+     * @param schemaGenJarPath
+     * @return Path to generated schema file.
+     */
+    private String generateServerSchemaXsd(LibertyWorkspace libertyWorkspace, Path schemaGenJarPath) {
+        //java -jar path/to/ws-schemagen.jar path/to/workspace/.libertyls/libertySchema.xsd
+        File tempDir = LibertyUtils.getTempDir(libertyWorkspace.getWorkspaceURI().toString());
+
+        //If tempDir is null, issue a warning for the current LibertyWorkspace URI and use the default cached schema file
+        if (tempDir == null) {
+            LOGGER.warning("Could not create a temporary directory for generating the schema file. The cached schema file will be used for the current workspace: " + libertyWorkspace.getWorkspaceString());
+            return null;
+        }
+
+        //TODO: (?) Add subfolders to tempDir: schema/xsd/liberty/server.xsd
+        File xsdDestFile = new File(tempDir, "server.xsd");
+        if (libertyWorkspace.getLibertyVersion()!= null && !libertyWorkspace.getLibertyVersion().isEmpty() &&
+                libertyWorkspace.getLibertyRuntime()!= null && !libertyWorkspace.getLibertyRuntime().isEmpty()) {
+            xsdDestFile = new File(tempDir, libertyWorkspace.getLibertyRuntime() + "-" + libertyWorkspace.getLibertyVersion() + ".xsd");
+        }
+
+        if (!xsdDestFile.exists()) {
+            try {
+                LOGGER.info("Generating schema file from: " + schemaGenJarPath.toString());
+                String xsdDestPath = xsdDestFile.getCanonicalPath();
+    
+                LOGGER.info("Generating schema file at: " + xsdDestPath);
+    
+                ProcessBuilder pb = new ProcessBuilder("java", "-jar", schemaGenJarPath.toAbsolutePath().toString(), xsdDestPath); //Add locale param here
+                pb.directory(tempDir);
+                pb.redirectErrorStream(true);
+                pb.redirectOutput(new File(tempDir, "schemagen.log"));
+    
+                Process proc = pb.start();
+                if (!proc.waitFor(30, TimeUnit.SECONDS)) {
+                    proc.destroy();
+                    LOGGER.warning("Exceeded 30 second timeout during schema file generation. Using cached schema.xsd file.");
+                    return null;
+                }
+
+                LOGGER.info("Caching schema file with URI: " + xsdDestFile.toURI().toString());
+            } catch (Exception e) {
+                LOGGER.warning(e.getMessage());
+                LOGGER.warning("Due to an exception during schema file generation, a cached schema file will be used.");
+                return null;
+            }
+        }
+
+        LOGGER.info("Using schema file at: " + xsdDestFile.toURI().toString());
+        return xsdDestFile.toURI().toString();
+    }
 
 }

--- a/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/models/settings/DevcMetadata.java
+++ b/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/models/settings/DevcMetadata.java
@@ -1,0 +1,42 @@
+/*******************************************************************************
+* Copyright (c) 2020, 2022 IBM Corporation and others.
+*
+* This program and the accompanying materials are made available under the
+* terms of the Eclipse Public License v. 2.0 which is available at
+* http://www.eclipse.org/legal/epl-2.0.
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*     IBM Corporation - initial API and implementation
+*******************************************************************************/
+
+package io.openliberty.tools.langserver.lemminx.models.settings;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlRootElement;
+
+@XmlRootElement(name = "devcModeMetaData")
+@XmlAccessorType(XmlAccessType.FIELD)
+public class DevcMetadata {
+
+    private String containerName;
+    private boolean containerAlive;
+
+    public String getContainerName() {
+        return containerName;
+    }
+
+    public void setContainerName(String containerName) {
+        this.containerName = containerName;
+    }
+
+    public boolean getContainerAlive() {
+        return containerAlive;
+    }
+
+    public void setContainerAlive(boolean containerAlive) {
+        this.containerAlive = containerAlive;
+    }
+}

--- a/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/models/settings/DevcMetadata.java
+++ b/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/models/settings/DevcMetadata.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2020, 2022 IBM Corporation and others.
+* Copyright (c) 2022 IBM Corporation and others.
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License v. 2.0 which is available at
@@ -32,7 +32,7 @@ public class DevcMetadata {
         this.containerName = containerName;
     }
 
-    public boolean getContainerAlive() {
+    public boolean isContainerAlive() {
         return containerAlive;
     }
 

--- a/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/services/DockerService.java
+++ b/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/services/DockerService.java
@@ -1,0 +1,151 @@
+/*******************************************************************************
+* Copyright (c) 2022 IBM Corporation and others.
+*
+* This program and the accompanying materials are made available under the
+* terms of the Eclipse Public License v. 2.0 which is available at
+* http://www.eclipse.org/legal/epl-2.0.
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*     IBM Corporation - initial API and implementation
+*******************************************************************************/
+
+package io.openliberty.tools.langserver.lemminx.services;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.text.MessageFormat;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Logger;
+
+import io.openliberty.tools.langserver.lemminx.util.LibertyUtils;
+
+public class DockerService {
+    private static final Logger LOGGER = Logger.getLogger(DockerService.class.getName());
+    private final int DOCKER_TIMEOUT = 20; // seconds
+
+    // Singleton so that only 1 Docker Service can be initialized and is
+    // shared between all Lemminx Language Feature Participants
+  
+    private static DockerService instance;
+  
+    public static DockerService getInstance() {
+        if (instance == null) {
+            instance = new DockerService();
+        }
+        return instance;
+    }
+
+    // saved paths 
+    public static final Path DEFAULT_CONTAINER_WLP_DIR = Paths.get("opt", "ol", "wlp");
+
+    public static final Path DEFAULT_CONTAINER_OL_PROPERTIES_PATH = 
+            DEFAULT_CONTAINER_WLP_DIR.resolve(Paths.get("lib", "versions", "openliberty.properties"));
+    public static final Path DEFAULT_CONTAINER_SCHEMAGEN_JAR_PATH = 
+            DEFAULT_CONTAINER_WLP_DIR.resolve(Paths.get("bin", "tools", "ws-schemagen.jar"));
+
+
+    /** ===== Public Methods ===== **/
+
+    /**
+     * Method to execute a command inside the specified container
+     * @param containerName
+     * @param cmd
+     */
+    public void dockerExec(String containerName, String cmd) {
+        // $ docker exec [OPTIONS] CONTAINER COMMAND [ARG...]
+        String dockerExec = MessageFormat.format("docker exec {0} {1}", containerName, cmd);
+        execDockerCmd(dockerExec);
+    }
+
+    /**
+     * Method to copy a file out from the specified container
+     * @param containerName
+     * @param containerSrc
+     * @param localDest
+     */
+    public void dockerCp(String containerName, String containerSrc, String localDest) {
+        // $ docker cp [OPTIONS] CONTAINER:SRC_PATH DEST_PATH|-
+        String dockerCp = MessageFormat.format("docker cp {0}:{1} {2}", containerName, containerSrc, localDest);
+        execDockerCmd(dockerCp);
+    }
+
+    /**
+     * Generate the schema file for a LibertyWorkspace using the ws-schemagen.jar from the corresponding container
+     * @param containerName
+     * @return Path to generated schema file.
+     * @throws IOException
+     */
+    public String generateServerSchemaXsdFromContainer(LibertyWorkspace libertyWorkspace) throws IOException {
+        File tempDir = LibertyUtils.getTempDir(libertyWorkspace.getWorkspaceString());
+        String libertyRuntime = libertyWorkspace.getLibertyRuntime();
+        String libertyVersion = libertyWorkspace.getLibertyVersion();
+        String xsdFileName = (libertyVersion != null && libertyRuntime != null &&
+                            !libertyVersion.isEmpty() && !libertyRuntime.isEmpty()) ?
+                            libertyRuntime + "-" + libertyVersion + ".xsd" :
+                            "server.xsd";
+        File xsdFile = new File(tempDir, xsdFileName);
+
+        if (!xsdFile.exists()) {
+            // $ java -jar {path to ws-schemagen.jar} {outputFile}
+            String containerOutputFileString = "/tmp/" + xsdFileName;
+            String cmd = MessageFormat.format("java -jar {0} {1}", DEFAULT_CONTAINER_SCHEMAGEN_JAR_PATH.toString(), containerOutputFileString);
+
+            // generate xsd file inside container
+            dockerExec(libertyWorkspace.getContainerName(), cmd);
+            // extract xsd file to local/temp dir
+            dockerCp(libertyWorkspace.getContainerName(), containerOutputFileString, tempDir.getCanonicalPath());
+        }
+        LOGGER.info("Using schema file at: " + xsdFile.toURI().toString());
+        return xsdFile.toURI().toString();
+    }
+
+
+    /** ===== Protected/Helper Methods ===== **/
+
+    /**
+     * @param timeout unit is seconds
+     * @return the stdout of the command or null for no output on stdout
+     */
+    protected String execDockerCmd(String command) {
+        String result = null;
+        try {
+            // debug("execDocker, timeout=" + timeout + ", cmd=" + command);
+            Process p = Runtime.getRuntime().exec(command);
+            p.waitFor(DOCKER_TIMEOUT, TimeUnit.SECONDS);
+            // After waiting for the process, handle the error case and normal termination.
+            if (p.exitValue() != 0) {
+                LOGGER.severe("Error running docker command, return value=" + p.exitValue());
+                // read messages from standard err
+                char[] d = new char[1023];
+                new InputStreamReader(p.getErrorStream()).read(d);
+                throw new RuntimeException(new String(d).trim()+" RC="+p.exitValue());
+            }
+            result = readStdOut(p);
+        } catch (IllegalThreadStateException  e) {
+            // the timeout was too short and the docker command has not yet completed. There is no exit value.
+            LOGGER.warning("IllegalThreadStateException, message="+e.getMessage());
+            throw new RuntimeException("The docker command did not complete within the timeout period: " + DOCKER_TIMEOUT + " seconds. ");
+        } catch (InterruptedException | IOException e) {
+            // If a runtime exception occurred in the server task, log and rethrow
+            throw new RuntimeException(e.getMessage());
+        }
+        return result;
+    }
+
+    protected String readStdOut(Process p) throws IOException, InterruptedException {
+        // Read all the output on stdout and return it to the caller
+        BufferedReader in = new BufferedReader(new InputStreamReader(p.getInputStream()));
+        String line;
+        StringBuffer allLines = new StringBuffer();
+        while ((line = in.readLine())!= null) {
+            allLines.append(line).append(" ");
+        }
+        return (allLines.length() > 0) ? allLines.toString() : null;
+    }
+}

--- a/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/services/LibertyWorkspace.java
+++ b/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/services/LibertyWorkspace.java
@@ -38,6 +38,10 @@ public class LibertyWorkspace {
     private List<Feature> installedFeatureList;
     private Set<String> configFiles;
 
+    // devc vars
+    private String containerName;
+    private boolean runningContainer;
+
     /**
      * Model of a Liberty Workspace. Each workspace indicates the
      * workspaceFolderURI, the Liberty version associated (may be cached), and if an
@@ -51,6 +55,8 @@ public class LibertyWorkspace {
         this.libertyRuntime = null;
         this.isLibertyInstalled = false;
         this.installedFeatureList = new ArrayList<Feature>();
+        this.containerName = null;
+        this.runningContainer = false;
 
         this.configFiles = new HashSet<String>();
         initConfigFileList();
@@ -59,7 +65,7 @@ public class LibertyWorkspace {
     public String getWorkspaceString() {
         return this.workspaceFolderURI;
     }
-    
+
     public URI getWorkspaceURI() {
         return URI.create(this.workspaceFolderURI);
     }
@@ -75,11 +81,11 @@ public class LibertyWorkspace {
     public String getLibertyVersion() {
         return this.libertyVersion;
     }
-    
+
     public void setLibertyRuntime(String libertyRuntime) {
         this.libertyRuntime = libertyRuntime;
     }
-    
+
     public String getLibertyRuntime() {
         return libertyRuntime;
     }
@@ -100,10 +106,27 @@ public class LibertyWorkspace {
         this.installedFeatureList = installedFeatureList;
     }
 
-    public void initConfigFileList() {
+    public String getContainerName() {
+        return containerName;
+    }
+
+    public void setContainerName(String containerName) {
+        this.containerName = containerName;
+    }
+
+    public boolean hasRunningContainer() {
+        return this.runningContainer;
+    }
+
+    public void setRunningContainer(boolean container) {
+        this.runningContainer = container;
+    }
+
+    private void initConfigFileList() {
         try {
-            List<Path> serverXmlList = Files.find(Paths.get(getWorkspaceURI()), Integer.MAX_VALUE, (filePath, fileAttributes) -> 
-                    LibertyUtils.isServerXMLFile(filePath.toString()))
+            List<Path> serverXmlList = Files
+                    .find(Paths.get(getWorkspaceURI()), Integer.MAX_VALUE,
+                            (filePath, fileAttributes) -> LibertyUtils.isServerXMLFile(filePath.toString()))
                     .collect(Collectors.toList());
             for (Path serverXml : serverXmlList) {
                 scanForConfigLocations(serverXml);
@@ -115,7 +138,7 @@ public class LibertyWorkspace {
     }
 
     // TODO: or use DOM
-    public void scanForConfigLocations(Path filePath) {
+    private void scanForConfigLocations(Path filePath) {
         try {
             String content = new String(Files.readAllBytes(filePath));
             // [^<] = All characters, including whitespaces/newlines, not equivalent to '<'
@@ -141,7 +164,7 @@ public class LibertyWorkspace {
     public boolean hasConfigFile(String fileString) {
         try {
             fileString = fileString.startsWith("file:") ? 
-                    new File(URI.create(fileString)).getCanonicalPath() : 
+                    new File(URI.create(fileString)).getCanonicalPath() :
                     new File(fileString).getCanonicalPath();
             return this.configFiles.contains(fileString);
         } catch (IOException e) {

--- a/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/util/LibertyUtils.java
+++ b/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/util/LibertyUtils.java
@@ -30,9 +30,15 @@ import java.util.concurrent.TimeUnit;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
+import javax.xml.bind.JAXBContext;
+import javax.xml.bind.JAXBException;
+import javax.xml.bind.Unmarshaller;
+
 import org.eclipse.lemminx.dom.DOMDocument;
 
 import io.openliberty.tools.langserver.lemminx.models.feature.Feature;
+import io.openliberty.tools.langserver.lemminx.models.settings.DevcMetadata;
+import io.openliberty.tools.langserver.lemminx.services.DockerService;
 import io.openliberty.tools.langserver.lemminx.services.LibertyProjectsManager;
 import io.openliberty.tools.langserver.lemminx.services.LibertyWorkspace;
 import io.openliberty.tools.langserver.lemminx.services.SettingsService;
@@ -148,18 +154,15 @@ public class LibertyUtils {
             return runtime;
         }
 
-        if (findFileInWorkspace(serverXMLUri, Paths.get("WebSphereApplicationServer.properties")) != null ) {
-            runtime = "wlp";
-            libertyWorkspace.setLibertyRuntime(runtime);
-            return runtime;
-        } else if (findFileInWorkspace(serverXMLUri, Paths.get("openliberty.properties")) != null ) {
+        if (findFileInWorkspace(serverXMLUri, Paths.get("openliberty.properties")) != null) {
             runtime = "ol";
-            libertyWorkspace.setLibertyRuntime(runtime);
-            return runtime;
-        } else {
-            // did not detect a new liberty properties file, return version from cache
-            return runtime;
+        } else if (findFileInWorkspace(serverXMLUri, Paths.get("WebSphereApplicationServer.properties")) != null ) {
+            runtime = "wlp";
         }
+        libertyWorkspace.setLibertyRuntime(runtime);
+
+        // did not detect a new liberty properties file, return version from cache
+        return runtime;
     }
 
     /**
@@ -194,6 +197,48 @@ public class LibertyUtils {
         if (version != null && libertyWorkspace.isLibertyInstalled()) {
             return version;
         }
+        
+        // todo: retrieve serverName
+        String serverName = "defaultServer";
+        Path devcMetadataFile = findFileInWorkspace(serverXMLUri, Paths.get(serverName + "-liberty-devc-metadata.xml"));
+
+        // detected a devc metadata file, calculate version
+        if (devcMetadataFile != null && devcMetadataFile.toFile().exists()) {
+            // new properties file, reset the installed features stored in the feature cache
+            // so that the installed features list will be regenerated as it may have
+            // changed between Liberty installations
+            libertyWorkspace.setInstalledFeatureList(new ArrayList<Feature>());
+
+            // add a file watcher on this file to monitor container health
+            watchFiles(devcMetadataFile, libertyWorkspace);
+
+            Properties prop = new Properties();
+            try {
+                DevcMetadata devcMetadata = unmarshalDevcMetadataFile(devcMetadataFile);
+
+                boolean containerAlive = devcMetadata.getContainerAlive();
+                String containerName = devcMetadata.getContainerName();
+                libertyWorkspace.setRunningContainer(containerAlive);
+                libertyWorkspace.setContainerName(containerName);
+                if (containerAlive) {
+                    DockerService docker = DockerService.getInstance();
+                    File containerPropertiesFile = new File(getTempDir(libertyWorkspace.getWorkspaceString()), "container.properties");
+                    docker.dockerCp(containerName, DockerService.DEFAULT_CONTAINER_OL_PROPERTIES_PATH.toString(), containerPropertiesFile.toString());
+                    FileInputStream fis = new FileInputStream(containerPropertiesFile);
+                    prop.load(fis);
+                    version = prop.getProperty("com.ibm.websphere.productVersion");
+                    libertyWorkspace.setLibertyVersion(version);
+                    libertyWorkspace.setLibertyInstalled(false);
+                    return version;
+                }
+                // if not alive, continue on
+            } catch (IOException e) {
+                LOGGER.warning("Failed to get version from running container specified by devc metadata file: " + devcMetadataFile.toString());
+                return null;
+            }
+        }
+
+        // consider todo: refactor logic
         Path propertiesFile = findFileInWorkspace(serverXMLUri, Paths.get("openliberty.properties"));
 
         // detected a new Liberty properties file, re-calculate version
@@ -220,9 +265,25 @@ public class LibertyUtils {
                         + e.getMessage());
                 return null;
             }
-        } else {
-            // did not detect a new liberty properties file, return version from cache
-            return version;
+        }
+        
+        // did not detect a new liberty properties file, return version from cache
+        return version;
+    }
+
+    /**
+     * Helper method to unmarshal/read the provided liberty-devc-metadata file.
+     * @param devcMetadataFile
+     * @return
+     */
+    private static DevcMetadata unmarshalDevcMetadataFile(Path devcMetadataFile) {
+        try {
+            JAXBContext jaxbContext = JAXBContext.newInstance(DevcMetadata.class);
+            Unmarshaller jaxbUnmarshaller = jaxbContext.createUnmarshaller();
+            return (DevcMetadata)jaxbUnmarshaller.unmarshal(devcMetadataFile.toFile());
+        } catch (JAXBException e) {
+            LOGGER.warning("Unable to unmarshal the devc metadata file: " + devcMetadataFile.toString());
+            return null;
         }
     }
 
@@ -258,18 +319,23 @@ public class LibertyUtils {
 
     /**
      * Watches the parent directory of the Liberty properties file in a separate
-     * thread. If the the contents of the directory have been modified or deleted,
-     * the installation of Liberty has changed and the corresponding Liberty
-     * Workspace item is updated.
+     * thread or actively watches a liberty-devc-metadata file. If the the contents 
+     * have been modified or deleted, the installation of Liberty has changed and 
+     * the corresponding Liberty Workspace item is updated.
      * 
-     * @param propertiesFile   openliberty.properties file to watch
+     * @param watchFile        openliberty.properties or *-liberty-devc.metadata.xml to watch
      * @param libertyWorkspace Liberty Workspace object, updated to indicate if
      *                         there is an associated installation of Liberty
      */
-    public static void watchFiles(Path propertiesFile, LibertyWorkspace libertyWorkspace) {
+    public static void watchFiles(Path watchFile, LibertyWorkspace libertyWorkspace) {     
+        boolean isProperties = watchFile.endsWith("openliberty.properties");
         try {
             WatchService watcher = FileSystems.getDefault().newWatchService();
-            propertiesFile.getParent().register(watcher, StandardWatchEventKinds.ENTRY_MODIFY);
+            if (isProperties) {
+                watchFile.getParent().register(watcher, StandardWatchEventKinds.ENTRY_MODIFY);
+            } else {
+                watchFile.register(watcher, StandardWatchEventKinds.ENTRY_MODIFY);
+            }
             thread = new Thread(() -> {
                 WatchKey watchKey = null;
                 try {
@@ -277,19 +343,30 @@ public class LibertyUtils {
                         watchKey = watcher.poll(5, TimeUnit.SECONDS);
                         if (watchKey != null) {
                             watchKey.pollEvents().stream().forEach(event -> {
-                                LOGGER.fine("Liberty properties file (" + propertiesFile + ") has been modified: "
-                                        + event.context());
-                                // if modified re-calculate version
-                                libertyWorkspace.setLibertyInstalled(false);
+                                if (isProperties) {
+                                    // if modified re-calculate version
+                                    LOGGER.fine("Liberty properties file (" + watchFile + ") has been modified: "
+                                    + event.context());
+                                    libertyWorkspace.setLibertyInstalled(false);
+                                } else {
+                                    // if modified, re-check container status
+                                    DevcMetadata devcMetadata = unmarshalDevcMetadataFile(watchFile);
+                                    libertyWorkspace.setRunningContainer(devcMetadata.getContainerAlive());
+                                }
                             });
 
                             // if watchkey.reset() returns false indicates that the parent folder has been
                             // deleted
                             boolean valid = watchKey.reset();
                             if (!valid) {
-                                // if deleted re-calculate version
-                                LOGGER.fine("Liberty properties file (" + propertiesFile + ") has been deleted");
-                                libertyWorkspace.setLibertyInstalled(false);
+                                if (isProperties) {
+                                    // if deleted re-calculate version
+                                    LOGGER.fine("Liberty properties file (" + watchFile + ") has been deleted");
+                                    libertyWorkspace.setLibertyInstalled(false);
+                                } else {
+                                    // metadata file deleted
+                                    libertyWorkspace.setRunningContainer(false);
+                                }
                             }
                         }
                     }

--- a/lemminx-liberty/src/test/java/io/openliberty/LibertyCompletionTest.java
+++ b/lemminx-liberty/src/test/java/io/openliberty/LibertyCompletionTest.java
@@ -30,7 +30,7 @@ public class LibertyCompletionTest {
                                 "<webApplication location=\"\"></webApplication>");
                 CompletionItem httpEndpointCompletion = c("httpEndpoint", "<httpEndpoint></httpEndpoint>");
 
-                final int TOTAL_ITEMS = 156; // total number of available completion items
+                final int TOTAL_ITEMS = 166; // total number of available completion items
 
                 XMLAssert.testCompletionFor(serverXML, null, serverXMLURI, TOTAL_ITEMS, applicationManagerCompletion,
                                 webApplicationCompletion, httpEndpointCompletion);
@@ -52,7 +52,7 @@ public class LibertyCompletionTest {
                 CompletionItem portCompletion = c("httpPort", "httpPort=\"\"");
                 CompletionItem enabledCompletion = c("enabled", "enabled=\"true\"");
 
-                final int TOTAL_ITEMS = 13; // total number of available completion items
+                final int TOTAL_ITEMS = 15; // total number of available completion items
 
                 XMLAssert.testCompletionFor(serverXML, null, serverXMLURI, TOTAL_ITEMS, portCompletion,
                                 enabledCompletion);

--- a/lemminx-liberty/src/test/java/io/openliberty/LibertyCompletionTest.java
+++ b/lemminx-liberty/src/test/java/io/openliberty/LibertyCompletionTest.java
@@ -30,7 +30,7 @@ public class LibertyCompletionTest {
                                 "<webApplication location=\"\"></webApplication>");
                 CompletionItem httpEndpointCompletion = c("httpEndpoint", "<httpEndpoint></httpEndpoint>");
 
-                final int TOTAL_ITEMS = 166; // total number of available completion items
+                final int TOTAL_ITEMS = 156; // total number of available completion items
 
                 XMLAssert.testCompletionFor(serverXML, null, serverXMLURI, TOTAL_ITEMS, applicationManagerCompletion,
                                 webApplicationCompletion, httpEndpointCompletion);
@@ -52,7 +52,7 @@ public class LibertyCompletionTest {
                 CompletionItem portCompletion = c("httpPort", "httpPort=\"\"");
                 CompletionItem enabledCompletion = c("enabled", "enabled=\"true\"");
 
-                final int TOTAL_ITEMS = 15; // total number of available completion items
+                final int TOTAL_ITEMS = 13; // total number of available completion items
 
                 XMLAssert.testCompletionFor(serverXML, null, serverXMLURI, TOTAL_ITEMS, portCompletion,
                                 enabledCompletion);

--- a/lemminx-liberty/src/test/java/io/openliberty/LibertyWorkspaceTest.java
+++ b/lemminx-liberty/src/test/java/io/openliberty/LibertyWorkspaceTest.java
@@ -1,0 +1,33 @@
+package io.openliberty;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+import java.net.URI;
+import java.net.URISyntaxException;
+
+import org.junit.jupiter.api.Test;
+
+import io.openliberty.tools.langserver.lemminx.services.LibertyWorkspace;
+
+public class LibertyWorkspaceTest {
+    
+    @Test
+    public void readDevcMetadata() throws URISyntaxException {
+        File srcResourcesDir = new File("src/test/resources");
+        URI resourcesDir = srcResourcesDir.toURI();
+        LibertyWorkspace libertyWorkspace = new LibertyWorkspace(resourcesDir.toString());
+        assertNull(libertyWorkspace.getContainerName());
+        assertFalse(libertyWorkspace.isContainerAlive());
+        
+        assertNotNull(libertyWorkspace.findDevcMetadata());
+        
+        assertEquals("liberty-dev", libertyWorkspace.getContainerName());
+        assertTrue(libertyWorkspace.isContainerAlive());
+    }
+
+}

--- a/lemminx-liberty/src/test/resources/server-liberty-devc-metadata.xml
+++ b/lemminx-liberty/src/test/resources/server-liberty-devc-metadata.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" ?>
+<devcModeMetaData>
+    <containerName>liberty-dev</containerName>
+    <containerAlive>true</containerAlive>
+</devcModeMetaData>


### PR DESCRIPTION
for #77 

added:
- `DevcMetadata` class to read/unmarshal `{serverName}-liberty-devc-metadata.xml` produced by the Liberty Common library
- `DockerService` class as an API for Docker, with `docker exec` and `docker cp` written to `dockerExec` and `dockerCp`
- `DockerService` also contains the method that generates the `server.xsd` from a specified container
- `LibertyWorkspace` added two vars with getters/setters for `devc`
- `LibertyUtils.watchFiles` has a boolean to watch for either a properties or metadata file, and watches parent dir or file accordingly.
- add simple metadata read test

minor change:
- Made the `initConfigFilesList` and associated scan public -> private
- `LibertyXSDURIResolver` indentation changed from 2 spaces -> 4 spaces