### PR TITLE
Tests and completion updates

### DIFF
--- a/.github/workflows/lemminx-liberty.yml
+++ b/.github/workflows/lemminx-liberty.yml
@@ -1,4 +1,4 @@
-name: Java CI - Lemminx Liberty
+name: Java CI - Lemminx Liberty & Liberty Language Server
 
 on:
   push:
@@ -19,6 +19,9 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 1.8
-      - name: Build with Maven
+      - name: Build Lemminx Liberty
         working-directory: ./lemminx-liberty
+        run: mvn -B package --file pom.xml
+      - name: Build Liberty Language Server
+        working-directory: ./liberty-ls
         run: mvn -B package --file pom.xml

--- a/liberty-ls/src/main/java/io/openliberty/tools/langserver/AbstractLanguageServer.java
+++ b/liberty-ls/src/main/java/io/openliberty/tools/langserver/AbstractLanguageServer.java
@@ -1,0 +1,56 @@
+/*******************************************************************************
+* Copyright (c) 2022 IBM Corporation and others.
+*
+* This program and the accompanying materials are made available under the
+* terms of the Eclipse Public License v. 2.0 which is available at
+* http://www.eclipse.org/legal/epl-2.0.
+*
+* SPDX-License-Identifier: EPL-2.0
+*******************************************************************************/
+package io.openliberty.tools.langserver;
+
+import java.util.logging.Logger;
+
+public class AbstractLanguageServer {
+    private final class LibertyServerRunnable implements Runnable {
+        @Override
+        public void run() {
+            LOGGER.info("Starting Liberty Language Server");
+            while (!shutdown && !Thread.currentThread().isInterrupted()) {
+                try {
+                    Thread.sleep(5000);
+                } catch (InterruptedException e) {
+                    LOGGER.warning(e.getMessage());
+                    Thread.currentThread().interrupt();
+                }
+            }
+            if (!Thread.currentThread().isInterrupted()) {
+                LOGGER.info("Liberty Language Server - Client vanished...");
+            }
+        }
+    }
+    private static final Logger LOGGER = Logger.getLogger(AbstractLanguageServer.class.getName());
+
+    private Thread runner;
+	private volatile boolean shutdown;
+
+    public int startServer() {
+        runner = new Thread(new LibertyServerRunnable(), "Liberty Language Client Watcher");
+        runner.start();
+        return 0;
+    }
+
+    public void stopServer() {
+        LOGGER.info("Stopping Liberty language server");
+        if (runner != null) {
+            runner.interrupt();
+        } else {
+            LOGGER.info("Received request to stop Liberty language server, but it wasn't started.");
+        }
+    }
+
+    public void shutdownServer() {
+        LOGGER.info("Shutting down language server");
+        shutdown = true;
+    }
+}

--- a/liberty-ls/src/main/java/io/openliberty/tools/langserver/LibertyLanguageServer.java
+++ b/liberty-ls/src/main/java/io/openliberty/tools/langserver/LibertyLanguageServer.java
@@ -23,13 +23,15 @@ import org.eclipse.lsp4j.InitializedParams;
 import org.eclipse.lsp4j.ServerCapabilities;
 import org.eclipse.lsp4j.TextDocumentSyncKind;
 import org.eclipse.lsp4j.services.LanguageClient;
+import org.eclipse.lsp4j.services.LanguageClientAware;
 import org.eclipse.lsp4j.services.LanguageServer;
 import org.eclipse.lsp4j.services.TextDocumentService;
 import org.eclipse.lsp4j.services.WorkspaceService;
 
 
-public class LibertyLanguageServer implements LanguageServer {
+public class LibertyLanguageServer extends AbstractLanguageServer implements LanguageServer, LanguageClientAware {
 
+    public static final String LANGUAGE_ID = "LANGUAGE_ID_LIBERTY";
     private static final Logger LOGGER = Logger.getLogger(LibertyLanguageServer.class.getName());
 
     private final WorkspaceService workspaceService;
@@ -77,13 +79,19 @@ public class LibertyLanguageServer implements LanguageServer {
     }
 
     @Override
+    public void connect(LanguageClient client) {
+        this.languageClient = client;
+    }
+
+    @Override
     public CompletableFuture<Object> shutdown() {
-        // TODO Auto-generated method stub
-        return null;
+        super.shutdownServer();
+        return CompletableFuture.completedFuture(new Object());
     }
 
     @Override
     public void exit() {
+        super.stopServer();
         System.exit(0);
     }
 

--- a/liberty-ls/src/main/java/io/openliberty/tools/langserver/model/propertiesfile/PropertiesEntryInstance.java
+++ b/liberty-ls/src/main/java/io/openliberty/tools/langserver/model/propertiesfile/PropertiesEntryInstance.java
@@ -95,7 +95,7 @@ public class PropertiesEntryInstance {
             if (propertyValueInstance.toString() != null && !isOnEntryKey(position)) {
                 return propertyValueInstance.getCompletions(position);
             } 
-            return propertyKeyInstance.getCompletions(position);
+            return propertyKeyInstance.getCompletions(this.getKey(), position);
         }
         return CompletableFuture.completedFuture(Collections.emptyList());
     }

--- a/liberty-ls/src/main/java/io/openliberty/tools/langserver/model/propertiesfile/PropertiesKeyInstance.java
+++ b/liberty-ls/src/main/java/io/openliberty/tools/langserver/model/propertiesfile/PropertiesKeyInstance.java
@@ -58,8 +58,8 @@ public class PropertiesKeyInstance {
         return CompletableFuture.completedFuture(hover);
     }
 
-    public CompletableFuture<List<CompletionItem>> getCompletions(Position position) {
-        List<String> matches = Messages.getMatchingKeys("", textDocumentItem);
+    public CompletableFuture<List<CompletionItem>> getCompletions(String enteredText, Position position) {
+        List<String> matches = Messages.getMatchingKeys(enteredText, textDocumentItem);
         List<CompletionItem> results = matches.stream().map(s -> new CompletionItem(s)).collect(Collectors.toList());
         return CompletableFuture.completedFuture(results);
     }

--- a/liberty-ls/src/main/java/io/openliberty/tools/langserver/utils/Messages.java
+++ b/liberty-ls/src/main/java/io/openliberty/tools/langserver/utils/Messages.java
@@ -82,8 +82,14 @@ public class Messages {
         }
         
         String filename = textDocument.getUri();
-        // remove completion results that don't contain the query string
-        Predicate<String> filter = s -> (!s.contains(query));
+        // remove completion results that don't contain the query string (case-insensitive search)
+        Predicate<String> filter = s -> {
+            for (int i = s.length() - query.length(); i >= 0; --i) {
+                if (s.regionMatches(true, i, query, 0, query.length()))
+                    return false;
+            }
+            return true;
+        };
         if (filename.contains("server.env")) { // server.env file
             List<String> keys = new ArrayList<String>(serverPropertyKeys);
             keys.removeIf(filter);

--- a/liberty-ls/src/main/java/io/openliberty/tools/langserver/utils/Messages.java
+++ b/liberty-ls/src/main/java/io/openliberty/tools/langserver/utils/Messages.java
@@ -9,11 +9,13 @@
 *******************************************************************************/
 package io.openliberty.tools.langserver.utils;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.MissingResourceException;
 import java.util.ResourceBundle;
+import java.util.function.Predicate;
 import java.util.logging.Logger;
 import java.util.regex.Pattern;
 
@@ -80,10 +82,16 @@ public class Messages {
         }
         
         String filename = textDocument.getUri();
+        // remove completion results that don't contain the query string
+        Predicate<String> filter = s -> (!s.contains(query));
         if (filename.contains("server.env")) { // server.env file
-            return serverPropertyKeys;
+            List<String> keys = new ArrayList<String>(serverPropertyKeys);
+            keys.removeIf(filter);
+            return keys;
         } else if (filename.contains("bootstrap.properties")) { // bootstrap.properties file
-            return bootstrapPropertyKeys;
+            List<String> keys = new ArrayList<String>(bootstrapPropertyKeys);
+            keys.removeIf(filter);
+            return keys;
         } else {
             return Collections.emptyList();
         }

--- a/liberty-ls/src/main/java/io/openliberty/tools/langserver/utils/ServerPropertyValues.java
+++ b/liberty-ls/src/main/java/io/openliberty/tools/langserver/utils/ServerPropertyValues.java
@@ -24,7 +24,7 @@ import io.openliberty.tools.langserver.ls.LibertyTextDocument;
  * Maps property keys with their list of valid values for server.env and bootstrap.properties
  */
 public class ServerPropertyValues {
-    private final static List<String> LOGGING_SOURCE_VALUES = Arrays.asList("message", "trace", "accessLog", "ffdc", "audit");
+    public final static List<String> LOGGING_SOURCE_VALUES = Arrays.asList("message", "trace", "accessLog", "ffdc", "audit");
     private final static List<String> BOOLEAN_VALUES_DEFAULT_TRUE = Arrays.asList("true", "false");
     private final static List<String> BOOLEAN_VALUES_DEFAULT_FALSE = Arrays.asList("false", "true");
     private final static List<String> YES_NO_VALUES = Arrays.asList("y", "n");

--- a/liberty-ls/src/main/java/io/openliberty/tools/langserver/utils/ServerPropertyValues.java
+++ b/liberty-ls/src/main/java/io/openliberty/tools/langserver/utils/ServerPropertyValues.java
@@ -25,9 +25,9 @@ import io.openliberty.tools.langserver.ls.LibertyTextDocument;
  */
 public class ServerPropertyValues {
     public final static List<String> LOGGING_SOURCE_VALUES = Arrays.asList("message", "trace", "accessLog", "ffdc", "audit");
-    private final static List<String> BOOLEAN_VALUES_DEFAULT_TRUE = Arrays.asList("true", "false");
-    private final static List<String> BOOLEAN_VALUES_DEFAULT_FALSE = Arrays.asList("false", "true");
-    private final static List<String> YES_NO_VALUES = Arrays.asList("y", "n");
+    public final static List<String> BOOLEAN_VALUES_DEFAULT_TRUE = Arrays.asList("true", "false");
+    public final static List<String> BOOLEAN_VALUES_DEFAULT_FALSE = Arrays.asList("false", "true");
+    public final static List<String> YES_NO_VALUES = Arrays.asList("y", "n");
     
     private static HashMap<String, List<String>> predefinedServerValues = new HashMap<String, List<String>>() {{
         put("WLP_DEBUG_SUSPEND", YES_NO_VALUES); // default yes

--- a/liberty-ls/src/test/java/io/openliberty/tools/langserver/AbstractLibertyLanguageServerTest.java
+++ b/liberty-ls/src/test/java/io/openliberty/tools/langserver/AbstractLibertyLanguageServerTest.java
@@ -103,7 +103,7 @@ public class AbstractLibertyLanguageServerTest {
     }
 
     private List<WorkspaceFolder> getTestResource(String name) throws URISyntaxException {
-        WorkspaceFolder workspaceFolder = new WorkspaceFolder(LibertyLanguageServerTest.class.getResource(name).toURI().toString());
+        WorkspaceFolder workspaceFolder = new WorkspaceFolder(AbstractLibertyLanguageServerTest.class.getResource(name).toURI().toString());
         return Arrays.asList(workspaceFolder);
     }
 

--- a/liberty-ls/src/test/java/io/openliberty/tools/langserver/AbstractLibertyLanguageServerTest.java
+++ b/liberty-ls/src/test/java/io/openliberty/tools/langserver/AbstractLibertyLanguageServerTest.java
@@ -98,13 +98,8 @@ public class AbstractLibertyLanguageServerTest {
     private InitializeParams getInitParams() throws URISyntaxException {
         InitializeParams params = new InitializeParams();
         params.setProcessId(new Random().nextInt());
-        params.setWorkspaceFolders(getTestResource("/workspace"));
+        // params.setWorkspaceFolders(getTestResource("/workspace"));
         return null;
-    }
-
-    private List<WorkspaceFolder> getTestResource(String name) throws URISyntaxException {
-        WorkspaceFolder workspaceFolder = new WorkspaceFolder(AbstractLibertyLanguageServerTest.class.getResource(name).toURI().toString());
-        return Arrays.asList(workspaceFolder);
     }
 
     private TextDocumentItem createTestTextDocument(String text, String fileSuffix) {

--- a/liberty-ls/src/test/java/io/openliberty/tools/langserver/AbstractLibertyLanguageServerTest.java
+++ b/liberty-ls/src/test/java/io/openliberty/tools/langserver/AbstractLibertyLanguageServerTest.java
@@ -1,0 +1,158 @@
+/*******************************************************************************
+* Copyright (c) 2022 IBM Corporation and others.
+*
+* This program and the accompanying materials are made available under the
+* terms of the Eclipse Public License v. 2.0 which is available at
+* http://www.eclipse.org/legal/epl-2.0.
+*
+* SPDX-License-Identifier: EPL-2.0
+*******************************************************************************/
+package io.openliberty.tools.langserver;
+
+import static org.junit.Assert.assertTrue;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.net.URISyntaxException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.stream.Collectors;
+
+import org.eclipse.lsp4j.CompletionItem;
+import org.eclipse.lsp4j.CompletionList;
+import org.eclipse.lsp4j.CompletionParams;
+import org.eclipse.lsp4j.DidOpenTextDocumentParams;
+import org.eclipse.lsp4j.InitializeParams;
+import org.eclipse.lsp4j.InitializeResult;
+import org.eclipse.lsp4j.InitializedParams;
+import org.eclipse.lsp4j.MessageActionItem;
+import org.eclipse.lsp4j.MessageParams;
+import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.PublishDiagnosticsParams;
+import org.eclipse.lsp4j.ShowMessageRequestParams;
+import org.eclipse.lsp4j.TextDocumentIdentifier;
+import org.eclipse.lsp4j.TextDocumentItem;
+import org.eclipse.lsp4j.WorkspaceFolder;
+import org.eclipse.lsp4j.jsonrpc.messages.Either;
+import org.eclipse.lsp4j.services.LanguageClient;
+import org.eclipse.lsp4j.services.TextDocumentService;
+import org.junit.AfterClass;
+
+public class AbstractLibertyLanguageServerTest {
+    protected static final String DUMMY_URI = "dummyUri";
+    private String extensionUsed;
+    protected static LibertyLanguageServer libertyLanguageServer;
+    protected PublishDiagnosticsParams lastPublishedDiagnostics;
+
+    public AbstractLibertyLanguageServerTest() {
+        super();
+    }
+
+    @AfterClass
+    public static void tearDown() {
+        if (libertyLanguageServer != null) {
+            libertyLanguageServer.shutdown();
+        }
+    }
+
+    protected LibertyLanguageServer initializeLanguageServer(InputStream stream, String fileSuffix) {
+        try (BufferedReader br = new BufferedReader(new InputStreamReader(stream))) {
+            return initializeLanguageServer(br.lines().collect(Collectors.joining("\n")), fileSuffix);
+        } catch (ExecutionException | InterruptedException | URISyntaxException | IOException e) {
+            return null;
+        }
+    }
+
+    private LibertyLanguageServer initializeLanguageServer(String text, String fileSuffix) throws URISyntaxException, InterruptedException, ExecutionException {
+        return initializeLanguageServer(fileSuffix, createTestTextDocument(text, fileSuffix));
+    }
+
+    protected LibertyLanguageServer initializeLanguageServer(String fileSuffix, TextDocumentItem... items) throws URISyntaxException, InterruptedException, ExecutionException {
+        this.extensionUsed = fileSuffix;
+        initializeLanguageServer(getInitParams());
+        for (TextDocumentItem item : items) {
+            libertyLanguageServer.getTextDocumentService().didOpen(new DidOpenTextDocumentParams(item));
+        }
+        return libertyLanguageServer;
+    }
+
+
+    private void initializeLanguageServer(InitializeParams params) throws InterruptedException, ExecutionException {
+        libertyLanguageServer = new LibertyLanguageServer();
+        libertyLanguageServer.connect(new DummyLanguageClient());
+        libertyLanguageServer.startServer();
+        CompletableFuture<InitializeResult> initialize = libertyLanguageServer.initialize(params);
+
+        assertTrue(initialize.isDone());
+        assertTrue(initialize.get().getCapabilities().getCompletionProvider().getResolveProvider());
+
+        InitializedParams initialized = new InitializedParams();
+        libertyLanguageServer.initialized(initialized);
+    }
+    
+    private InitializeParams getInitParams() throws URISyntaxException {
+        InitializeParams params = new InitializeParams();
+        params.setProcessId(new Random().nextInt());
+        params.setWorkspaceFolders(getTestResource("/workspace"));
+        return null;
+    }
+
+    private List<WorkspaceFolder> getTestResource(String name) throws URISyntaxException {
+        WorkspaceFolder workspaceFolder = new WorkspaceFolder(LibertyLanguageServerTest.class.getResource(name).toURI().toString());
+        return Arrays.asList(workspaceFolder);
+    }
+
+    private TextDocumentItem createTestTextDocument(String text, String fileSuffix) {
+        return createTestTextDocumentWithFilename(text, DUMMY_URI + fileSuffix);
+    }
+
+    private TextDocumentItem createTestTextDocumentWithFilename(String text, String fileName) {
+        return new TextDocumentItem(fileName, LibertyLanguageServer.LANGUAGE_ID, 0, text);
+    }
+
+    final class DummyLanguageClient implements LanguageClient {
+
+        @Override
+        public void telemetryEvent(Object object) {
+        }
+
+        @Override
+        public void publishDiagnostics(PublishDiagnosticsParams diagnostics) {
+            AbstractLibertyLanguageServerTest.this.lastPublishedDiagnostics = diagnostics;
+        }
+
+        @Override
+        public void showMessage(MessageParams messageParams) {
+        }
+
+        @Override
+        public CompletableFuture<MessageActionItem> showMessageRequest(ShowMessageRequestParams requestParams) {
+            return null;
+        }
+
+        @Override
+        public void logMessage(MessageParams message) {
+        }
+    }
+
+    protected CompletableFuture<Either<List<CompletionItem>, CompletionList>> getCompletionFor(LibertyLanguageServer libertyLanguageServer, Position position) {
+        return getCompletionFor(libertyLanguageServer, position, DUMMY_URI + extensionUsed);
+    }
+
+    protected CompletableFuture<Either<List<CompletionItem>, CompletionList>> getCompletionFor(LibertyLanguageServer libertyLanguageServer, Position position,
+            String filename) {
+        TextDocumentService tds = libertyLanguageServer.getTextDocumentService();
+        CompletionParams completionParams = new CompletionParams(new TextDocumentIdentifier(filename), position);
+        return tds.completion(completionParams);
+    }
+
+    protected CompletionItem createExpectedCompletionItem() {
+        CompletionItem expectedItem = new CompletionItem("");
+        return expectedItem;
+    }
+}

--- a/liberty-ls/src/test/java/io/openliberty/tools/langserver/completion/AbstractCompletionTest.java
+++ b/liberty-ls/src/test/java/io/openliberty/tools/langserver/completion/AbstractCompletionTest.java
@@ -1,0 +1,44 @@
+/*******************************************************************************
+* Copyright (c) 2022 IBM Corporation and others.
+*
+* This program and the accompanying materials are made available under the
+* terms of the Eclipse Public License v. 2.0 which is available at
+* http://www.eclipse.org/legal/epl-2.0.
+*
+* SPDX-License-Identifier: EPL-2.0
+*******************************************************************************/
+package io.openliberty.tools.langserver.completion;
+
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+
+import org.eclipse.lsp4j.CompletionItem;
+
+import io.openliberty.tools.langserver.AbstractLibertyLanguageServerTest;
+
+public class AbstractCompletionTest extends AbstractLibertyLanguageServerTest {
+
+    /**
+     * 
+     * @param completionItems - List<CompletionItem> from Liberty Language Server completion
+     * @param valuesToFind - array of Strings that completionItems should contain
+     */
+    protected void checkCompletionsContainAllStrings(List<CompletionItem> completionItems, String... valuesToFind) {
+        List<String> keys = new LinkedList<>(Arrays.asList(valuesToFind));
+        Iterator<CompletionItem> it = completionItems.iterator();
+        while (it.hasNext()) {
+            String itemLabel = it.next().getLabel();
+            assertTrue(keys.remove(itemLabel));
+        }
+        assertTrue(keys.isEmpty());
+    }
+
+    protected CompletionItem createExpectedCompletionItem(String value) {
+        CompletionItem expectedCompletionItem = new CompletionItem(value);
+        return expectedCompletionItem;
+    }
+}

--- a/liberty-ls/src/test/java/io/openliberty/tools/langserver/completion/BootstrapPropertyCompletionTest.java
+++ b/liberty-ls/src/test/java/io/openliberty/tools/langserver/completion/BootstrapPropertyCompletionTest.java
@@ -10,12 +10,8 @@
 package io.openliberty.tools.langserver.completion;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
 import java.net.URISyntaxException;
-import java.util.Arrays;
-import java.util.Iterator;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -27,11 +23,10 @@ import org.eclipse.lsp4j.TextDocumentItem;
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
 import org.junit.Test;
 
-import io.openliberty.tools.langserver.AbstractLibertyLanguageServerTest;
 import io.openliberty.tools.langserver.LibertyLanguageServer;
 import io.openliberty.tools.langserver.utils.ServerPropertyValues;
 
-public class BootstrapPropertyCompletionTest extends AbstractLibertyLanguageServerTest {
+public class BootstrapPropertyCompletionTest extends AbstractCompletionTest {
     @Test
     public void testKeyCompletion() throws Exception {
         CompletableFuture<Either<List<CompletionItem>, CompletionList>> completions = getCompletion("webs", new Position(0, 4));
@@ -40,44 +35,70 @@ public class BootstrapPropertyCompletionTest extends AbstractLibertyLanguageServ
     }
 
     @Test
-    public void testKeyCompletion2() throws Exception {
+    public void testKeyCompletionPurge() throws Exception {
         CompletableFuture<Either<List<CompletionItem>, CompletionList>> completions = getCompletion("purge", new Position(0, 5));
         List<CompletionItem> completionItems = completions.get().getLeft();
-        assertEquals(4, completionItems.size()); // expected 4 results for "purge" key
+        assertEquals(4, completionItems.size());
 
-        // Check that completionItems contains all 4 results for "purge" autocomplete
-        List<String> purgeKeys = new LinkedList<>(Arrays.asList("com.ibm.hpel.log.purgeMaxSize", "com.ibm.hpel.log.purgeMinTime", "com.ibm.hpel.trace.purgeMaxSize", "com.ibm.hpel.trace.purgeMinTime"));
-        Iterator<CompletionItem> it = completionItems.iterator();
-        while (it.hasNext()) {
-            String itemLabel = it.next().getLabel();
-            assertTrue(purgeKeys.remove(itemLabel));
-        }
-        assertTrue(purgeKeys.isEmpty()); // account for all keys containing "purge"
+        checkCompletionsContainAllStrings(completionItems, 
+            "com.ibm.hpel.log.purgeMaxSize", "com.ibm.hpel.log.purgeMinTime", "com.ibm.hpel.trace.purgeMaxSize", "com.ibm.hpel.trace.purgeMinTime");
     }
 
     @Test
-    public void testValueCompletion() throws Exception {
+    public void testKeyCompletionOnEquivalentProperty() throws Exception {
+        CompletableFuture<Either<List<CompletionItem>, CompletionList>> completions = getCompletion("com.ibm.ws.logging.message", new Position(0, 5));
+        List<CompletionItem> completionItems = completions.get().getLeft();
+        assertEquals(3, completionItems.size()); // expected 4 results for "purge" key
+        
+        checkCompletionsContainAllStrings(completionItems, "com.ibm.ws.logging.message.file.name", "com.ibm.ws.logging.message.format", "com.ibm.ws.logging.message.source");
+    }
+
+    @Test
+    public void testKeyCompletionDir() throws Exception {
+        CompletableFuture<Either<List<CompletionItem>, CompletionList>> completions = getCompletion("dir", new Position(0, 5));
+        List<CompletionItem> completionItems = completions.get().getLeft();
+        assertEquals(8, completionItems.size());
+    }
+
+    @Test
+    public void testValueCompletionForTraceLoggingSource() throws Exception {
         CompletableFuture<Either<List<CompletionItem>, CompletionList>> completions = getCompletion("com.ibm.ws.logging.console.source=", new Position(0, 38));
         List<CompletionItem> completionItems = completions.get().getLeft();
         assertEquals(5, completionItems.size());
 
-        List<String> keys = new LinkedList<>(ServerPropertyValues.LOGGING_SOURCE_VALUES);
-        Iterator<CompletionItem> it = completionItems.iterator();
-        while (it.hasNext()) {
-            String itemLabel = it.next().getLabel();
-            assertTrue(keys.remove(itemLabel));
-        }
-        assertTrue(keys.isEmpty());
+        checkCompletionsContainAllStrings(completionItems, (String[])ServerPropertyValues.LOGGING_SOURCE_VALUES.toArray());
+    }
+
+    @Test
+    public void testValueCompletionForTraceLoggingFormat() throws Exception {
+        CompletableFuture<Either<List<CompletionItem>, CompletionList>> completions = getCompletion("com.ibm.ws.logging.trace.format=", new Position(0, 38));
+        List<CompletionItem> completionItems = completions.get().getLeft();
+        assertEquals(4, completionItems.size());
+
+        checkCompletionsContainAllStrings(completionItems, "ENHANCED", "BASIC", "TBASIC", "ADVANCED");
+    }
+
+    @Test
+    public void testValueCompletionForBoolean() throws Exception {
+        CompletableFuture<Either<List<CompletionItem>, CompletionList>> completions = getCompletion("com.ibm.ws.logging.copy.system.streams=", new Position(0, 38));
+        List<CompletionItem> completionItems = completions.get().getLeft();
+        assertEquals(2, completionItems.size());
+
+        checkCompletionsContainAllStrings(completionItems, (String[])ServerPropertyValues.BOOLEAN_VALUES_DEFAULT_TRUE.toArray());
+    }
+
+    @Test
+    public void testValueCompletionLogProvider() throws Exception {
+        CompletableFuture<Either<List<CompletionItem>, CompletionList>> completions = getCompletion("websphere.log.provider=", new Position(0, 38));
+        List<CompletionItem> completionItems = completions.get().getLeft();
+        assertEquals(1, completionItems.size());
+
+        checkCompletionsContainAllStrings(completionItems, "binaryLogging-1.0");
     }
 
     protected CompletableFuture<Either<List<CompletionItem>, CompletionList>> getCompletion(String enteredText, Position position) throws URISyntaxException, InterruptedException, ExecutionException {
         String filename = "bootstrap.properties";
         LibertyLanguageServer lls = initializeLanguageServer(filename, new TextDocumentItem(filename, LibertyLanguageServer.LANGUAGE_ID, 0, enteredText));
         return getCompletionFor(lls, position, filename);
-    }
-
-    protected CompletionItem createExpectedCompletionItem(String value) {
-        CompletionItem expectedCompletionItem = new CompletionItem(value);
-        return expectedCompletionItem;
     }
 }

--- a/liberty-ls/src/test/java/io/openliberty/tools/langserver/completion/BootstrapPropertyCompletionTest.java
+++ b/liberty-ls/src/test/java/io/openliberty/tools/langserver/completion/BootstrapPropertyCompletionTest.java
@@ -1,0 +1,83 @@
+/*******************************************************************************
+* Copyright (c) 2022 IBM Corporation and others.
+*
+* This program and the accompanying materials are made available under the
+* terms of the Eclipse Public License v. 2.0 which is available at
+* http://www.eclipse.org/legal/epl-2.0.
+*
+* SPDX-License-Identifier: EPL-2.0
+*******************************************************************************/
+package io.openliberty.tools.langserver.completion;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.net.URISyntaxException;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+
+import org.eclipse.lsp4j.CompletionItem;
+import org.eclipse.lsp4j.CompletionList;
+import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.TextDocumentItem;
+import org.eclipse.lsp4j.jsonrpc.messages.Either;
+import org.junit.Test;
+
+import io.openliberty.tools.langserver.AbstractLibertyLanguageServerTest;
+import io.openliberty.tools.langserver.LibertyLanguageServer;
+import io.openliberty.tools.langserver.utils.ServerPropertyValues;
+
+public class BootstrapPropertyCompletionTest extends AbstractLibertyLanguageServerTest {
+    @Test
+    public void testKeyCompletion() throws Exception {
+        CompletableFuture<Either<List<CompletionItem>, CompletionList>> completions = getCompletion("webs", new Position(0, 4));
+
+        assertEquals("websphere.log.provider", completions.get().getLeft().get(0).getLabel());
+    }
+
+    @Test
+    public void testKeyCompletion2() throws Exception {
+        CompletableFuture<Either<List<CompletionItem>, CompletionList>> completions = getCompletion("purge", new Position(0, 5));
+        List<CompletionItem> completionItems = completions.get().getLeft();
+        assertEquals(4, completionItems.size()); // expected 4 results for "purge" key
+
+        // Check that completionItems contains all 4 results for "purge" autocomplete
+        List<String> purgeKeys = new LinkedList<>(Arrays.asList("com.ibm.hpel.log.purgeMaxSize", "com.ibm.hpel.log.purgeMinTime", "com.ibm.hpel.trace.purgeMaxSize", "com.ibm.hpel.trace.purgeMinTime"));
+        Iterator<CompletionItem> it = completionItems.iterator();
+        while (it.hasNext()) {
+            String itemLabel = it.next().getLabel();
+            assertTrue(purgeKeys.remove(itemLabel));
+        }
+        assertTrue(purgeKeys.isEmpty()); // account for all keys containing "purge"
+    }
+
+    @Test
+    public void testValueCompletion() throws Exception {
+        CompletableFuture<Either<List<CompletionItem>, CompletionList>> completions = getCompletion("com.ibm.ws.logging.console.source=", new Position(0, 38));
+        List<CompletionItem> completionItems = completions.get().getLeft();
+        assertEquals(5, completionItems.size());
+
+        List<String> keys = new LinkedList<>(ServerPropertyValues.LOGGING_SOURCE_VALUES);
+        Iterator<CompletionItem> it = completionItems.iterator();
+        while (it.hasNext()) {
+            String itemLabel = it.next().getLabel();
+            assertTrue(keys.remove(itemLabel));
+        }
+        assertTrue(keys.isEmpty());
+    }
+
+    protected CompletableFuture<Either<List<CompletionItem>, CompletionList>> getCompletion(String enteredText, Position position) throws URISyntaxException, InterruptedException, ExecutionException {
+        String filename = "bootstrap.properties";
+        LibertyLanguageServer lls = initializeLanguageServer(filename, new TextDocumentItem(filename, LibertyLanguageServer.LANGUAGE_ID, 0, enteredText));
+        return getCompletionFor(lls, position, filename);
+    }
+
+    protected CompletionItem createExpectedCompletionItem(String value) {
+        CompletionItem expectedCompletionItem = new CompletionItem(value);
+        return expectedCompletionItem;
+    }
+}

--- a/liberty-ls/src/test/java/io/openliberty/tools/langserver/completion/ServerEnvCompletionTest.java
+++ b/liberty-ls/src/test/java/io/openliberty/tools/langserver/completion/ServerEnvCompletionTest.java
@@ -1,0 +1,120 @@
+/*******************************************************************************
+* Copyright (c) 2022 IBM Corporation and others.
+*
+* This program and the accompanying materials are made available under the
+* terms of the Eclipse Public License v. 2.0 which is available at
+* http://www.eclipse.org/legal/epl-2.0.
+*
+* SPDX-License-Identifier: EPL-2.0
+*******************************************************************************/
+package io.openliberty.tools.langserver.completion;
+
+import static org.junit.Assert.assertEquals;
+
+import java.net.URISyntaxException;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+
+import org.eclipse.lsp4j.CompletionItem;
+import org.eclipse.lsp4j.CompletionList;
+import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.TextDocumentItem;
+import org.eclipse.lsp4j.jsonrpc.messages.Either;
+import org.junit.Test;
+
+import io.openliberty.tools.langserver.LibertyLanguageServer;
+import io.openliberty.tools.langserver.utils.ServerPropertyValues;
+
+public class ServerEnvCompletionTest extends AbstractCompletionTest {
+    
+    @Test
+    public void testKeyCompletionLogging() throws Exception {
+        CompletableFuture<Either<List<CompletionItem>, CompletionList>> completions = getCompletion("logging", new Position(0, 5));
+        List<CompletionItem> completionItems = completions.get().getLeft();
+        assertEquals(8, completionItems.size());
+
+        checkCompletionsContainAllStrings(completionItems, 
+            "WLP_LOGGING_JSON_FIELD_MAPPINGS",
+            "WLP_LOGGING_CONSOLE_FORMAT",
+            "WLP_LOGGING_CONSOLE_LOGLEVEL",
+            "WLP_LOGGING_CONSOLE_SOURCE",
+            "WLP_LOGGING_MESSAGE_FORMAT",
+            "WLP_LOGGING_MESSAGE_SOURCE",
+            "WLP_LOGGING_APPS_WRITE_JSON",
+            "WLP_LOGGING_JSON_ACCESS_LOG_FIELDS"
+        );
+    }
+
+    @Test
+    public void testKeyCompletionDebug() throws Exception {
+        CompletableFuture<Either<List<CompletionItem>, CompletionList>> completions = getCompletion("deb", new Position(0, 5));
+        List<CompletionItem> completionItems = completions.get().getLeft();
+        assertEquals(3, completionItems.size());
+
+        checkCompletionsContainAllStrings(completionItems, 
+            "WLP_DEBUG_ADDRESS",
+            "WLP_DEBUG_SUSPEND",
+            "WLP_DEBUG_REMOTE"
+        );
+    }
+
+    @Test
+    public void testKeyCompletionWLP() throws Exception {
+        CompletableFuture<Either<List<CompletionItem>, CompletionList>> completions = getCompletion("wlp", new Position(0, 5));
+        List<CompletionItem> completionItems = completions.get().getLeft();
+        assertEquals(13, completionItems.size());
+    }
+
+    @Test
+    public void testValueCompletionForLoggingSource() throws Exception {
+        CompletableFuture<Either<List<CompletionItem>, CompletionList>> completions = getCompletion("WLP_LOGGING_CONSOLE_SOURCE=", new Position(0, 38));
+        List<CompletionItem> completionItems = completions.get().getLeft();
+        assertEquals(5, completionItems.size());
+
+        checkCompletionsContainAllStrings(completionItems, (String[])ServerPropertyValues.LOGGING_SOURCE_VALUES.toArray());
+    }
+
+    @Test
+    public void testValueCompletionForConsoleLoggingFormat() throws Exception {
+        CompletableFuture<Either<List<CompletionItem>, CompletionList>> completions = getCompletion("WLP_LOGGING_CONSOLE_FORMAT=", new Position(0, 38));
+        List<CompletionItem> completionItems = completions.get().getLeft();
+        assertEquals(4, completionItems.size());
+
+        checkCompletionsContainAllStrings(completionItems, "DEV", "SIMPLE", "JSON", "TBASIC");
+    }
+
+    @Test
+    public void testValueCompletionForMessageLoggingFormat() throws Exception {
+        CompletableFuture<Either<List<CompletionItem>, CompletionList>> completions = getCompletion("WLP_LOGGING_MESSAGE_FORMAT=", new Position(0, 38));
+        List<CompletionItem> completionItems = completions.get().getLeft();
+        assertEquals(3, completionItems.size());
+
+        checkCompletionsContainAllStrings(completionItems, "SIMPLE", "JSON", "TBASIC");
+    }
+    
+    @Test
+    public void testValueCompletionForYesNo() throws Exception {
+        CompletableFuture<Either<List<CompletionItem>, CompletionList>> completions = getCompletion("WLP_DEBUG_SUSPEND=", new Position(0, 20));
+        List<CompletionItem> completionItems = completions.get().getLeft();
+        assertEquals(2, completionItems.size());
+
+        checkCompletionsContainAllStrings(completionItems, (String[])ServerPropertyValues.YES_NO_VALUES.toArray());
+
+    }
+    
+    @Test
+    public void testValueCompletionForBoolean() throws Exception {
+        CompletableFuture<Either<List<CompletionItem>, CompletionList>> completions = getCompletion("WLP_LOGGING_APPS_WRITE_JSON=", new Position(0, 38));
+        List<CompletionItem> completionItems = completions.get().getLeft();
+        assertEquals(2, completionItems.size());
+
+        checkCompletionsContainAllStrings(completionItems, (String[])ServerPropertyValues.BOOLEAN_VALUES_DEFAULT_TRUE.toArray());
+    }
+
+    protected CompletableFuture<Either<List<CompletionItem>, CompletionList>> getCompletion(String enteredText, Position position) throws URISyntaxException, InterruptedException, ExecutionException {
+        String filename = "server.env";
+        LibertyLanguageServer lls = initializeLanguageServer(filename, new TextDocumentItem(filename, LibertyLanguageServer.LANGUAGE_ID, 0, enteredText));
+        return getCompletionFor(lls, position, filename);
+    }
+}

--- a/liberty-ls/src/test/java/io/openliberty/tools/langserver/hover/BootstrapPropertyHoverTest.java
+++ b/liberty-ls/src/test/java/io/openliberty/tools/langserver/hover/BootstrapPropertyHoverTest.java
@@ -1,0 +1,52 @@
+/*******************************************************************************
+* Copyright (c) 2022 IBM Corporation and others.
+*
+* This program and the accompanying materials are made available under the
+* terms of the Eclipse Public License v. 2.0 which is available at
+* http://www.eclipse.org/legal/epl-2.0.
+*
+* SPDX-License-Identifier: EPL-2.0
+*******************************************************************************/
+package io.openliberty.tools.langserver.hover;
+
+import static org.junit.Assert.assertEquals;
+
+import java.net.URISyntaxException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+
+import org.eclipse.lsp4j.Hover;
+import org.eclipse.lsp4j.HoverParams;
+import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.TextDocumentIdentifier;
+import org.eclipse.lsp4j.TextDocumentItem;
+import org.junit.Test;
+
+import io.openliberty.tools.langserver.AbstractLibertyLanguageServerTest;
+import io.openliberty.tools.langserver.LibertyLanguageServer;
+
+public class BootstrapPropertyHoverTest extends AbstractLibertyLanguageServerTest {
+    
+    @Test
+    public void testHoverOnPropertyName() throws Exception {
+        String propertyEntry = "wlp.install.dir=/some/dir";
+        CompletableFuture<Hover> hover = getHover(propertyEntry, 5);
+
+        assertEquals("The directory where the Open Liberty runtime is installed.", hover.get().getContents().getRight().getValue());
+    }
+
+    @Test
+    public void testHoverOnEquivalentProperty() throws Exception {
+        String propertyEntry = "com.ibm.ws.logging.message.format=simple";
+        CompletableFuture<Hover> hover = getHover(propertyEntry, 5);
+
+        assertEquals("This setting specifies the required format for the messages.log file. Valid values are `simple` or `json` format. By default, messageFormat is set to `simple`.", hover.get().getContents().getRight().getValue());
+    }
+
+    private CompletableFuture<Hover> getHover(String propertyEntry, int position) throws URISyntaxException, InterruptedException, ExecutionException {
+        String filename = "bootstrap.properties";
+        LibertyLanguageServer lls = initializeLanguageServer(filename, new TextDocumentItem(filename, LibertyLanguageServer.LANGUAGE_ID, 0, propertyEntry));
+        HoverParams hoverParams = new HoverParams(new TextDocumentIdentifier(filename), new Position(0, position));
+        return lls.getTextDocumentService().hover(hoverParams);
+    }
+}

--- a/liberty-ls/src/test/java/io/openliberty/tools/langserver/hover/ServerEnvHoverTest.java
+++ b/liberty-ls/src/test/java/io/openliberty/tools/langserver/hover/ServerEnvHoverTest.java
@@ -1,0 +1,44 @@
+/*******************************************************************************
+* Copyright (c) 2022 IBM Corporation and others.
+*
+* This program and the accompanying materials are made available under the
+* terms of the Eclipse Public License v. 2.0 which is available at
+* http://www.eclipse.org/legal/epl-2.0.
+*
+* SPDX-License-Identifier: EPL-2.0
+*******************************************************************************/
+package io.openliberty.tools.langserver.hover;
+
+import static org.junit.Assert.assertEquals;
+
+import java.net.URISyntaxException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+
+import org.eclipse.lsp4j.Hover;
+import org.eclipse.lsp4j.HoverParams;
+import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.TextDocumentIdentifier;
+import org.eclipse.lsp4j.TextDocumentItem;
+import org.junit.Test;
+
+import io.openliberty.tools.langserver.AbstractLibertyLanguageServerTest;
+import io.openliberty.tools.langserver.LibertyLanguageServer;
+
+public class ServerEnvHoverTest extends AbstractLibertyLanguageServerTest {
+    
+    @Test
+    public void testHoverOnPropertyName() throws Exception {
+        String propertyEntry = "LOG_FILE=log.txt";
+        CompletableFuture<Hover> hover = getHover(propertyEntry, 1);
+
+        assertEquals("The log file name. This log file is only used if the server start command is run in the background through the start action.", hover.get().getContents().getRight().getValue());
+    }
+
+    private CompletableFuture<Hover> getHover(String propertyEntry, int position) throws URISyntaxException, InterruptedException, ExecutionException {
+        String filename = "server.env";
+        LibertyLanguageServer lls = initializeLanguageServer(filename, new TextDocumentItem(filename, LibertyLanguageServer.LANGUAGE_ID, 0, propertyEntry));
+        HoverParams hoverParams = new HoverParams(new TextDocumentIdentifier(filename), new Position(0, position));
+        return lls.getTextDocumentService().hover(hoverParams);
+    }
+}


### PR DESCRIPTION
Some work for #89 and resolves #107 

- Modify Github Actions to run the build for liberty-ls
- Add tests for hover and completion features for liberty-ls
- Modify completion behavior a bit to filter results on language server-side, instead of relying completely on client-side automatic filtering.