### PR TITLE
Set kind to property for keys

### DIFF
--- a/liberty-ls/src/main/java/io/openliberty/tools/langserver/model/propertiesfile/PropertiesKeyInstance.java
+++ b/liberty-ls/src/main/java/io/openliberty/tools/langserver/model/propertiesfile/PropertiesKeyInstance.java
@@ -84,7 +84,13 @@ public class PropertiesKeyInstance {
             String keyToUse = key == null ? item.getLabel() : key;
             String desc = Messages.getPropDescription(keyToUse);
             item.setDetail(desc);
-            item.setKind(CompletionItemKind.Text);
+            // if setDefault is true, we are dealing with values which are considered text.
+            // otherwise we are dealing with keys which are considered properties.
+            if (setDefault) {
+                item.setKind(CompletionItemKind.Text);
+            } else {
+                item.setKind(CompletionItemKind.Property);
+            }
         }
     }
 

--- a/liberty-ls/src/test/java/io/openliberty/tools/langserver/completion/AbstractCompletionTest.java
+++ b/liberty-ls/src/test/java/io/openliberty/tools/langserver/completion/AbstractCompletionTest.java
@@ -65,6 +65,9 @@ public class AbstractCompletionTest extends AbstractLibertyLanguageServerTest {
                 String nextItemDetail = nextItem.getDetail();
                 assertNotNull(nextItemDetail);
                 assertTrue("The CompletionItem actual detail: "+nextItemDetail+" did not match expected: "+detail, nextItemDetail.equals(detail));
+
+                CompletionItemKind kind = nextItem.getKind();
+                assertTrue("Unexpected CompletionItemKind: "+kind+" expected: "+CompletionItemKind.Text, kind == CompletionItemKind.Text);
             } else {
                 if (nextItem.getLabel().equals(key)) {
                     String nextItemDetail = nextItem.getDetail();
@@ -74,10 +77,10 @@ public class AbstractCompletionTest extends AbstractLibertyLanguageServerTest {
                 } else {
                     assertNotNull(nextItem.getDetail());
                 }
-            }
-            CompletionItemKind kind = nextItem.getKind();
-            assertTrue("Unexpected CompletionItemKind: "+kind+" expected: "+CompletionItemKind.Text, kind == CompletionItemKind.Text);
 
+                CompletionItemKind kind = nextItem.getKind();
+                assertTrue("Unexpected CompletionItemKind: "+kind+" expected: "+CompletionItemKind.Property, kind == CompletionItemKind.Property);
+            }
         }
         assertTrue(found);
     }


### PR DESCRIPTION
Fixes #95 

Addressing @evie-lau concern over how VS Code displayed Text kind vs Property kind.