### PR TITLE
Install shaded artifact

### DIFF
--- a/lemminx-liberty/pom.xml
+++ b/lemminx-liberty/pom.xml
@@ -56,7 +56,8 @@
                             <goal>shade</goal>
                         </goals>
                         <configuration>
-                            <finalName>${project.artifactId}-${project.version}-jar-with-dependencies</finalName>
+                            <shadedArtifactAttached>true</shadedArtifactAttached>
+                            <shadedClassifierName>jar-with-dependencies</shadedClassifierName>
                             <createDependencyReducedPom>false</createDependencyReducedPom>
                             <filters>
                                 <filter>

--- a/liberty-ls/pom.xml
+++ b/liberty-ls/pom.xml
@@ -86,7 +86,8 @@
                         </goals>
                         <configuration>
                             <id>make-assembly</id>
-                            <finalName>${project.artifactId}-${project.version}-jar-with-dependencies</finalName>
+                            <shadedArtifactAttached>true</shadedArtifactAttached>
+                            <shadedClassifierName>jar-with-dependencies</shadedClassifierName>
                             <createDependencyReducedPom>false</createDependencyReducedPom>
                             <filters>
                                 <filter>


### PR DESCRIPTION
The latest snapshot builds only published the original `jar` and not the `jar-with-dependencies`. The Jenkins job publishes the installed artifacts from the build. When I switched to using the `maven-shade-plugin`, it caused the `jar-with-dependencies` to not get installed. Adding some configuration to the `maven-shade-plugin` to cause it to get installed.

Note: I tried several combinations to get the shaded jar as the only installed artifact. They all had undesirable side affects (the installed artifact name was not what I wanted no matter what config I tried). Even though we currently do not know of any need for the original `jar`, it will cause less churn to leave it as is.