### PR TITLE
Update github actions

### DIFF
--- a/.github/workflows/lemminx-liberty.yml
+++ b/.github/workflows/lemminx-liberty.yml
@@ -14,9 +14,9 @@ jobs:
         os: [ubuntu-latest, windows-latest]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Java
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
           java-version: 17

--- a/.github/workflows/lemminx-liberty.yml
+++ b/.github/workflows/lemminx-liberty.yml
@@ -2,7 +2,6 @@ name: Java CI - Lemminx Liberty & Liberty Language Server
 
 on:
   push:
-    branches: [main]
   pull_request:
     branches: [main]
 

--- a/.github/workflows/lemminx-liberty.yml
+++ b/.github/workflows/lemminx-liberty.yml
@@ -2,6 +2,7 @@ name: Java CI - Lemminx Liberty & Liberty Language Server
 
 on:
   push:
+    branches: '**'
   pull_request:
     branches: [main]
 


### PR DESCRIPTION
Github actions is upgrading to node 16, as node 12 is deprecated. 
Updated some actions, which include actions/checkout and actions/setup-java from v2 to v3.

Also allow actions to run on all pushed branches, which will allow everyone to see tests run on their own forks before opening PRs. This will have no effect on this main repo as no one should be pushing new branches, except in special scenarios.