### PR TITLE
Update to latest LemMinx release

### DIFF
--- a/lemminx-liberty/pom.xml
+++ b/lemminx-liberty/pom.xml
@@ -10,7 +10,7 @@
     <url>https://github.com/OpenLiberty/liberty-language-server</url>
 
     <properties>
-        <lemminx.version>0.21.0</lemminx.version>
+        <lemminx.version>0.22.0</lemminx.version>
       </properties>
 
     <scm>


### PR DESCRIPTION
Fixes #83 

Use latest `0.22.0` version of Eclipse LemMinX which contains the fix for displaying hover descriptions for all elements in the `server.xml` file.