### PR TITLE
Create NOTICES file and have build delete intermediate NOTICE and leg…

### DIFF
--- a/NOTICES
+++ b/NOTICES
@@ -1,0 +1,290 @@
+Begin NOTICES AND INFORMATION FOR Liberty Config Language Server
+Copyright 2022 IBM Corporation and others
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+TABLE OF CONTENTS
+
+THIS IBM NOTICES FILE CONSISTS OF THE FOLLOWING SECTIONS:
+
+APACHE V2
+CDDL V1  
+ECLIPSE DISTRIBUTION LICENSE  
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+APACHE SOFTWARE LICENSE 2.0
+
+The Program includes some or all of the following that IBM obtained
+under the Apache License Version 2.0:
+
+Apache Commons Lang
+Copyright 2001-2022 The Apache Software Foundation
+Home page: https://commons.apache.org/proper/commons-lang/
+
+----
+
+Apache License
+Version 2.0, January 2004
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+----
+
+END OF APACHE LICENSE 2.0 NOTICES AND INFORMATION
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+COMMON DEVELOPMENT AND DISTRIBUTION LICENSE V1
+
+The Program includes the following components that IBM obtained under the Common Development and Distribution License V1:
+ 
+PROJECTS
+
+JavaBeans(TM) Activation Framework
+
+  Maven coordinates: https://repo1.maven.org/maven2/javax/activation/activation/1.1/
+  Source code is available via the URL: https://repo1.maven.org/maven2/javax/activation/activation/1.1/activation-1.1-sources.jar
+
+Streaming API for XML
+
+  Maven coordinates: https://repo1.maven.org/maven2/javax/xml/stream/stax-api/1.0-2/
+  Source code is available via the URL: https://repo1.maven.org/maven2/javax/xml/stream/stax-api/1.0-2/stax-api-1.0-2-sources.jar
+
+END OF COMMON DEVELOPMENT AND DISTRIBUTION LICENSE V1 NOTICES AND INFORMATION
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+ECLIPSE DISTRIBUTION LICENSE
+
+The Program includes the following components that IBM obtained under the Eclipse Distribution License:
+ 
+PROJECTS
+
+JAXB Runtime
+
+  Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+  Maven coordinates: https://repo1.maven.org/maven2/org/glassfish/jaxb/jaxb-runtime/2.3.3
+
+Jakarta XML Binding API
+
+  Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+  Maven coordinates: https://repo1.maven.org/maven2/jakarta/xml/bind/jakarta.xml.bind-api/2.3.3
+
+TXW2 Runtime
+
+  Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+  Maven coordinates: https://repo1.maven.org/maven2/org/glassfish/jaxb/txw2/2.3.3
+
+istack common utility code runtime
+
+  Copyright (c) 2017 Oracle and/or its affiliates. All rights reserved.
+  Maven coordinates: https://repo1.maven.org/maven2/com/sun/istack/istack-commons-runtime/3.0.11
+
+Jakarta Activation
+
+  Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+  Maven coordinates: https://repo1.maven.org/maven2/com/sun/activation/jakarta.activation/1.2.2
+
+
+NOTICE TEXT
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+  - Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+
+  - Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+
+  - Neither the name of the Eclipse Foundation, Inc. nor the names of its
+    contributors may be used to endorse or promote products derived
+    from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE
+
+END OF ECLIPSE DISTRIBUTION LICENSE NOTICES AND INFORMATION
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+END OF NOTICES AND INFORMATION FILE
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++

--- a/lemminx-liberty/pom.xml
+++ b/lemminx-liberty/pom.xml
@@ -34,6 +34,14 @@
     </distributionManagement>
 
     <build>
+        <resources>
+            <resource>
+                <directory>${project.basedir}/..</directory>
+                <includes>
+                    <include>NOTICES</include>
+                </includes>
+            </resource>
+        </resources>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -72,12 +80,15 @@
                                 </filter>
                             </filters>
                             <transformers>
-                                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheLicenseResourceTransformer"/>
-                                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheNoticeResourceTransformer">
-                                    <addHeader>false</addHeader>
-                                </transformer>
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.DontIncludeResourceTransformer">
-                                    <resource>.html</resource>
+                                    <resources>
+                                        <resource>.html</resource>
+                                        <resource>META-INF/NOTICE</resource>
+                                        <resource>META-INF/NOTICE.txt</resource>
+                                        <resource>META-INF/NOTICE.md</resource>
+                                        <resource>META-INF/LICENSE.txt</resource>
+                                        <resource>META-INF/LICENSE.md</resource>
+                                     </resources>
                                 </transformer>
                             </transformers>
                         </configuration>

--- a/lemminx-liberty/pom.xml
+++ b/lemminx-liberty/pom.xml
@@ -36,6 +36,9 @@
     <build>
         <resources>
             <resource>
+                <directory>src/main/resources</directory>
+            </resource>
+            <resource>
                 <directory>${project.basedir}/..</directory>
                 <includes>
                     <include>NOTICES</include>

--- a/liberty-ls/pom.xml
+++ b/liberty-ls/pom.xml
@@ -116,9 +116,12 @@
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.DontIncludeResourceTransformer">
                                     <resources>
                                         <resource>.html</resource>
+                                        <resource>.html</resource>
                                         <resource>META-INF/NOTICE</resource>
-                                        <resource>META-INF/LICENSE.txt</resource>
                                         <resource>META-INF/NOTICE.txt</resource>
+                                        <resource>META-INF/NOTICE.md</resource>
+                                        <resource>META-INF/LICENSE.txt</resource>
+                                        <resource>META-INF/LICENSE.md</resource>
                                     </resources>
                                 </transformer>
                             </transformers>

--- a/liberty-ls/pom.xml
+++ b/liberty-ls/pom.xml
@@ -72,6 +72,12 @@
             <resource>
                 <directory>src/main/resources</directory>
             </resource>
+            <resource>
+                <directory>${project.basedir}/..</directory>
+                <includes>
+                    <include>NOTICES</include>
+                </includes>
+            </resource>
         </resources>
         <plugins>
             <plugin>
@@ -107,12 +113,13 @@
                                         <Main-Class>io.openliberty.tools.langserver.LibertyLanguageServerLauncher</Main-Class>
                                     </manifestEntries>
                                 </transformer>
-                                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheLicenseResourceTransformer"/>
-                                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheNoticeResourceTransformer">
-                                    <addHeader>false</addHeader>
-                                </transformer>
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.DontIncludeResourceTransformer">
-                                    <resource>.html</resource>
+                                    <resources>
+                                        <resource>.html</resource>
+                                        <resource>META-INF/NOTICE</resource>
+                                        <resource>META-INF/LICENSE.txt</resource>
+                                        <resource>META-INF/NOTICE.txt</resource>
+                                    </resources>
                                 </transformer>
                             </transformers>
                         </configuration>


### PR DESCRIPTION
…al files and zip up this one

Signed-off-by: Scott Kurz <skurz@us.ibm.com>

Fixes #131

This PR takes the Liberty Tools Eclipse legal information we'd been maintaing here: 
https://github.com/OpenLiberty/liberty-tools-eclipse/blob/main/bundles/io.openliberty.tools.eclipse.lsp4e/about.html

and tries to refactor it to fit into the format of the Open Liberty runtime:
https://github.com/OpenLiberty/open-liberty/blob/integration/dev/build.image/publish/NOTICES
(which is a generated file).

I'm not saying this is a very common structure, but it's maybe one way to do it.  

I do agree that the Apache license & notice resource transformers initially seem to solve a problem that sounds like the one we're solving.   I'm not sure how to take them further though.   I'm not sure they work on non-Apache licenses and notices either.   It seemed better to me just to delete the individual license/notice files that were dragged along from the prereqs and start top-down by looking at the POM dependency tree.