### PR TITLE
CreateFile fix

### DIFF
--- a/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/codeactions/CreateFile.java
+++ b/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/codeactions/CreateFile.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2022 IBM Corporation and others.
+* Copyright (c) 2022, 2023 IBM Corporation and others.
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License v. 2.0 which is available at

--- a/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/codeactions/CreateFile.java
+++ b/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/codeactions/CreateFile.java
@@ -41,8 +41,8 @@ public class CreateFile implements ICodeActionParticipant {
             File parentFile = LibertyUtils.getDocumentAsFile(document).getParentFile();
             String locationValue = document.findNodeAt(document.offsetAt(diagnostic.getRange().getEnd())).getAttribute("location");
             codeActions.add(CodeActionFactory.createFile(
-                "Create the missing server config file relative from this file.", 
-                new File(parentFile, locationValue).getCanonicalPath(), 
+                "Create the missing server config file relative from this file.",
+                new File(parentFile, locationValue).toURI().toString(), 
                 EMPTY_SERVER_CONFIG, diagnostic));
 
             /* Uncomment to add option when the need is found */

--- a/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/util/LibertyConstants.java
+++ b/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/util/LibertyConstants.java
@@ -29,6 +29,6 @@ public final class LibertyConstants {
     public static final String PUBLIC_VISIBILITY = "PUBLIC";
 
     public static final String WLP_USER_CONFIG_DIR = "/usr/shared/config/";
-    public static final String SERVER_CONFIG_DROPINS_DEFAULTS = "/configDropins/default/";
+    public static final String SERVER_CONFIG_DROPINS_DEFAULTS = "/configDropins/defaults/";
     public static final String SERVER_CONFIG_DROPINS_OVERRIDES = "/configDropins/overrides";
 }

--- a/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/util/LibertyConstants.java
+++ b/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/util/LibertyConstants.java
@@ -28,7 +28,7 @@ public final class LibertyConstants {
 
     public static final String PUBLIC_VISIBILITY = "PUBLIC";
 
-    public static final String WLP_USER_CONFIG_DIR = File.separator + String.join(File.separator, "usr", "shared", "config") + File.separator;
-    public static final String SERVER_CONFIG_DROPINS_DEFAULTS = File.separator + String.join(File.separator, "configDropins", "defaults") + File.separator;
-    public static final String SERVER_CONFIG_DROPINS_OVERRIDES = File.separator + String.join(File.separator, "configDropins", "overrides") + File.separator;
+    public static final String WLP_USER_CONFIG_DIR = "/usr/shared/config/";
+    public static final String SERVER_CONFIG_DROPINS_DEFAULTS = "/configDropins/default/";
+    public static final String SERVER_CONFIG_DROPINS_OVERRIDES = "/configDropins/overrides";
 }

--- a/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/util/LibertyConstants.java
+++ b/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/util/LibertyConstants.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2020, 2022, 2023 IBM Corporation and others.
+* Copyright (c) 2020, 2023 IBM Corporation and others.
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License v. 2.0 which is available at
@@ -26,7 +26,8 @@ public final class LibertyConstants {
 
     public static final String PUBLIC_VISIBILITY = "PUBLIC";
 
+    // following URI standard of using "/"
     public static final String WLP_USER_CONFIG_DIR = "/usr/shared/config/";
     public static final String SERVER_CONFIG_DROPINS_DEFAULTS = "/configDropins/defaults/";
-    public static final String SERVER_CONFIG_DROPINS_OVERRIDES = "/configDropins/overrides";
+    public static final String SERVER_CONFIG_DROPINS_OVERRIDES = "/configDropins/overrides/";
 }

--- a/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/util/LibertyConstants.java
+++ b/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/util/LibertyConstants.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2020, 2022 IBM Corporation and others.
+* Copyright (c) 2020, 2022, 2023 IBM Corporation and others.
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,8 +11,6 @@
 *     IBM Corporation - initial API and implementation
 *******************************************************************************/
 package io.openliberty.tools.langserver.lemminx.util;
-
-import java.io.File;
 
 public final class LibertyConstants {
     private LibertyConstants() {

--- a/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/util/LibertyUtils.java
+++ b/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/util/LibertyUtils.java
@@ -61,6 +61,10 @@ public class LibertyUtils {
     }
 
     public static boolean isConfigDirFile(String filePath) {
+        if (File.separator.equals("\\")) {
+            filePath = filePath.replace("\\", "/");
+        }
+
         return filePath.contains(LibertyConstants.WLP_USER_CONFIG_DIR) ||
                 filePath.contains(LibertyConstants.SERVER_CONFIG_DROPINS_DEFAULTS) ||
                 filePath.contains(LibertyConstants.SERVER_CONFIG_DROPINS_OVERRIDES);

--- a/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/util/LibertyUtils.java
+++ b/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/util/LibertyUtils.java
@@ -1,5 +1,5 @@
- /*******************************************************************************
-* Copyright (c) 2020, 2022 IBM Corporation and others.
+/*******************************************************************************
+* Copyright (c) 2020, 2022, 2023 IBM Corporation and others.
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License v. 2.0 which is available at
@@ -58,7 +58,7 @@ public class LibertyUtils {
 
     public static boolean isServerXMLFile(DOMDocument file) {
         return file.getDocumentURI().endsWith("/" + LibertyConstants.SERVER_XML);
-    } 
+    }
 
     public static boolean isConfigDirFile(String filePath) {
         return filePath.contains(LibertyConstants.WLP_USER_CONFIG_DIR) ||

--- a/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/util/LibertyUtils.java
+++ b/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/util/LibertyUtils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2020, 2022, 2023 IBM Corporation and others.
+* Copyright (c) 2020, 2023 IBM Corporation and others.
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License v. 2.0 which is available at

--- a/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/util/LibertyUtils.java
+++ b/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/util/LibertyUtils.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+ /*******************************************************************************
 * Copyright (c) 2020, 2022 IBM Corporation and others.
 *
 * This program and the accompanying materials are made available under the
@@ -58,19 +58,19 @@ public class LibertyUtils {
 
     public static boolean isServerXMLFile(DOMDocument file) {
         return file.getDocumentURI().endsWith("/" + LibertyConstants.SERVER_XML);
-    }
+    } 
 
     public static boolean isConfigDirFile(String filePath) {
-        if (File.separator.equals("\\")) {
-            filePath = filePath.replace("\\", "/");
-        }
-
         return filePath.contains(LibertyConstants.WLP_USER_CONFIG_DIR) ||
                 filePath.contains(LibertyConstants.SERVER_CONFIG_DROPINS_DEFAULTS) ||
                 filePath.contains(LibertyConstants.SERVER_CONFIG_DROPINS_OVERRIDES);
     }
 
     public static boolean isConfigXMLFile(String filePath) {
+        if (File.separator.equals("\\")) {
+            filePath = filePath.replace("\\", "/");
+        }
+
         return isServerXMLFile(filePath) || isConfigDirFile(filePath) ||
                 LibertyProjectsManager.getInstance().getWorkspaceFolder(filePath).hasConfigFile(filePath);
     }

--- a/lemminx-liberty/src/test/java/io/openliberty/LibertyWorkspaceTest.java
+++ b/lemminx-liberty/src/test/java/io/openliberty/LibertyWorkspaceTest.java
@@ -1,18 +1,18 @@
 package io.openliberty;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
+import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 
 import org.junit.jupiter.api.Test;
 
 import io.openliberty.tools.langserver.lemminx.services.LibertyWorkspace;
+import io.openliberty.tools.langserver.lemminx.util.LibertyUtils;
 
 public class LibertyWorkspaceTest {
     
@@ -29,5 +29,23 @@ public class LibertyWorkspaceTest {
         // assertNotNull(libertyWorkspace.findDevcMetadata());
         // assertEquals("liberty-dev", libertyWorkspace.getContainerName());
         // assertTrue(libertyWorkspace.isContainerAlive());
+    }
+
+    @Test
+    public void testBackslashConfigDetection() throws IOException {
+        // run test on Windows
+        if (File.separator.equals("/")) {
+            return;
+        }
+
+        File mockXML = new File("src/test/resources/configDropins/defaults/my.xml");
+        String filePathString = mockXML.getCanonicalPath();
+        URI filePathURI = mockXML.toURI();
+
+        assertFalse(LibertyUtils.isConfigDirFile(filePathString));
+        assertTrue(LibertyUtils.isConfigDirFile(filePathURI.toString()));
+        // mock replacement
+        filePathString = filePathString.replace("\\", "/");
+        assertTrue(LibertyUtils.isConfigDirFile(filePathString));
     }
 }

--- a/lemminx-liberty/src/test/java/io/openliberty/LibertyWorkspaceTest.java
+++ b/lemminx-liberty/src/test/java/io/openliberty/LibertyWorkspaceTest.java
@@ -1,16 +1,3 @@
-/*******************************************************************************
-* Copyright (c) 2022, 2023 IBM Corporation and others.
-*
-* This program and the accompanying materials are made available under the
-* terms of the Eclipse Public License v. 2.0 which is available at
-* http://www.eclipse.org/legal/epl-2.0.
-*
-* SPDX-License-Identifier: EPL-2.0
-*
-* Contributors:
-*     IBM Corporation - initial API and implementation
-*******************************************************************************/
-
 package io.openliberty;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;

--- a/lemminx-liberty/src/test/java/io/openliberty/LibertyWorkspaceTest.java
+++ b/lemminx-liberty/src/test/java/io/openliberty/LibertyWorkspaceTest.java
@@ -1,3 +1,16 @@
+/*******************************************************************************
+* Copyright (c) 2022, 2023 IBM Corporation and others.
+*
+* This program and the accompanying materials are made available under the
+* terms of the Eclipse Public License v. 2.0 which is available at
+* http://www.eclipse.org/legal/epl-2.0.
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*     IBM Corporation - initial API and implementation
+*******************************************************************************/
+
 package io.openliberty;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;


### PR DESCRIPTION
Correction for the LCLS code action for CreateFile. 

Problem occurred in IntelliJ on Windows:
```
2023-03-28 12:22:48,709 [1704719] SEVERE - #c.i.o.a.i.FlushQueue - Illegal character in opaque part at index 2: C:\Users\Evie\Downloads\maven-project\src\main\liberty\config\test1.xml
java.lang.IllegalArgumentException: Illegal character in opaque part at index 2: C:\Users\Evie\Downloads\maven-project\src\main\liberty\config\test1.xml
	at java.base/java.net.URI.create(URI.java:906)
	at io.openliberty.tools.intellij.lsp4mp.lsp4ij.LSPIJUtils.applyWorkspaceEdit(LSPIJUtils.java:165)
	at io.openliberty.tools.intellij.lsp4mp.lsp4ij.operations.codeactions.LSPCodeActionIntentionAction.apply(LSPCodeActionIntentionAction.java:96)
	at 
```

And here's a snapshot comparing the string outputs of `getCanonicalPath()` to `toUri().toString()`
![image](https://user-images.githubusercontent.com/8934136/228319752-3ac29d74-0e0f-4abe-8df5-edef7b8f7de1.png)
