### PR TITLE
CreateFile Code Action URI correction

### DIFF
--- a/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/codeactions/CreateFile.java
+++ b/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/codeactions/CreateFile.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2022 IBM Corporation and others.
+* Copyright (c) 2022, 2023 IBM Corporation and others.
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License v. 2.0 which is available at
@@ -42,7 +42,7 @@ public class CreateFile implements ICodeActionParticipant {
             String locationValue = document.findNodeAt(document.offsetAt(diagnostic.getRange().getEnd())).getAttribute("location");
             codeActions.add(CodeActionFactory.createFile(
                 "Create the missing server config file relative from this file.", 
-                new File(parentFile, locationValue).getCanonicalPath(), 
+                new File(parentFile, locationValue).toURI().toString(), 
                 EMPTY_SERVER_CONFIG, diagnostic));
 
             /* Uncomment to add option when the need is found */


### PR DESCRIPTION
Correction for the LCLS code action for CreateFile. 

Problem occurred in IntelliJ on Windows:
```
2023-03-28 12:22:48,709 [1704719] SEVERE - #c.i.o.a.i.FlushQueue - Illegal character in opaque part at index 2: C:\Users\Evie\Downloads\maven-project\src\main\liberty\config\test1.xml
java.lang.IllegalArgumentException: Illegal character in opaque part at index 2: C:\Users\Evie\Downloads\maven-project\src\main\liberty\config\test1.xml
	at java.base/java.net.URI.create(URI.java:906)
	at io.openliberty.tools.intellij.lsp4mp.lsp4ij.LSPIJUtils.applyWorkspaceEdit(LSPIJUtils.java:165)
	at io.openliberty.tools.intellij.lsp4mp.lsp4ij.operations.codeactions.LSPCodeActionIntentionAction.apply(LSPCodeActionIntentionAction.java:96)
	at 
```

And here's a snapshot comparing the string outputs of `getCanonicalPath()` to `toUri().toString()`
![image](https://user-images.githubusercontent.com/8934136/228319752-3ac29d74-0e0f-4abe-8df5-edef7b8f7de1.png)
