### PR TITLE
Update notices and version for 1.0 release

### DIFF
--- a/NOTICES
+++ b/NOTICES
@@ -1,13 +1,31 @@
-Begin NOTICES AND INFORMATION FOR Liberty Config Language Server
-Copyright 2022 IBM Corporation and others
-++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+NOTICES AND INFORMATION FOR <Liberty Config Language Server>
+
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
 TABLE OF CONTENTS
 
 THIS IBM NOTICES FILE CONSISTS OF THE FOLLOWING SECTIONS:
 
-APACHE V2
-CDDL V1  
-ECLIPSE DISTRIBUTION LICENSE  
+CDDL-1.0
+Apache-2.0
+EPL-2.0
+MIT
+BSD-3-Clause
+
+
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+COMMON DEVELOPMENT AND DISTRIBUTION LICENSE V1
+
+The Program includes some or all of the following that IBM obtained
+under the Common Development and Distribution License V1
+(source code available via the indicated URL):
+
+javax.activation:activation | https://repo1.maven.org/maven2/javax/activation/activation/1.1/activation-1.1-sources.jar
+
+END OF COMMON DEVELOPMENT AND DISTRIBUTION V1 LICENSE NOTICES AND INFORMATION
+
 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 APACHE SOFTWARE LICENSE 2.0
@@ -15,11 +33,17 @@ APACHE SOFTWARE LICENSE 2.0
 The Program includes some or all of the following that IBM obtained
 under the Apache License Version 2.0:
 
-Apache Commons Lang
-Copyright 2001-2022 The Apache Software Foundation
-Home page: https://commons.apache.org/proper/commons-lang/
-
-----
+com.google.code.findbugs:jsr305
+com.google.code.gson:gson
+com.google.errorprone:error_prone_annotations
+com.google.guava:failureaccess
+com.google.guava:guava
+com.google.guava:listenablefuture
+com.google.j2objc:j2objc-annotations
+com.kotcrab.remark:remark
+org.apache.commons:commons-lang3
+xerces:xercesImpl
+xml-resolver:xml-resolver
 
 Apache License
 Version 2.0, January 2004
@@ -40,7 +64,7 @@ TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
    control with that entity. For the purposes of this definition,
    "control" means (i) the power, direct or indirect, to cause the
    direction or management of such entity, whether by contract or
-   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   otherwise, or (ii) ownership of fifty percent (50%%) or more of the
    outstanding shares, or (iii) beneficial ownership of such entity.
 
    "You" (or "Your") shall mean an individual or Legal Entity
@@ -198,92 +222,106 @@ TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
 END OF TERMS AND CONDITIONS
 
-----
-
 END OF APACHE LICENSE 2.0 NOTICES AND INFORMATION
+
+
 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-COMMON DEVELOPMENT AND DISTRIBUTION LICENSE V1
+ECLIPSE PUBLIC LICENSE, VERSION 2
 
-The Program includes the following components that IBM obtained under the Common Development and Distribution License V1:
- 
-PROJECTS
+The Program includes some or all of the following that IBM obtained
+under the Eclipse Public License (source code available via the
+indicated URL):
 
-JavaBeans(TM) Activation Framework
+org.eclipse.lemminx:org.eclipse.lemminx | https://mvnrepository.com/artifact/org.eclipse.lemminx/org.eclipse.lemminx/0.22.0
+org.eclipse.lsp4j:org.eclipse.lsp4j | https://mvnrepository.com/artifact/org.eclipse.lsp4j/org.eclipse.lsp4j.debug/0.14.0
+org.eclipse.lsp4j:org.eclipse.lsp4j.generator | https://mvnrepository.com/artifact/org.eclipse.lsp4j/org.eclipse.lsp4j.generator/0.14.0
+org.eclipse.lsp4j:org.eclipse.lsp4j.jsonrpc | https://mvnrepository.com/artifact/org.eclipse.lsp4j/org.eclipse.lsp4j.jsonrpc/0.14.0
+org.eclipse.xtend:org.eclipse.xtend.lib | https://mvnrepository.com/artifact/org.eclipse.xtend/org.eclipse.xtend.lib/2.28.0
+org.eclipse.xtend:org.eclipse.xtend.lib.macro | https://mvnrepository.com/artifact/org.eclipse.xtend/org.eclipse.xtend.lib.macro/2.28.0
+org.eclipse.xtext:org.eclipse.xtext.xbase.lib | https://mvnrepository.com/artifact/org.eclipse.xtext/org.eclipse.xtext.xbase.lib/2.28.0
 
-  Maven coordinates: https://repo1.maven.org/maven2/javax/activation/activation/1.1/
-  Source code is available via the URL: https://repo1.maven.org/maven2/javax/activation/activation/1.1/activation-1.1-sources.jar
+END OF ECLIPSE PUBLIC LICENSE, VERSION 2 NOTICES AND INFORMATION
 
-Streaming API for XML
 
-  Maven coordinates: https://repo1.maven.org/maven2/javax/xml/stream/stax-api/1.0-2/
-  Source code is available via the URL: https://repo1.maven.org/maven2/javax/xml/stream/stax-api/1.0-2/stax-api-1.0-2-sources.jar
-
-END OF COMMON DEVELOPMENT AND DISTRIBUTION LICENSE V1 NOTICES AND INFORMATION
 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-ECLIPSE DISTRIBUTION LICENSE
+MIT LICENSE
 
-The Program includes the following components that IBM obtained under the Eclipse Distribution License:
- 
-PROJECTS
+The Program includes some or all of the following that IBM obtained
+under the MIT License:
 
-JAXB Runtime
+isorelax:isorelax | Copyright (c) 2001-2002, SourceForge ISO-RELAX Project (ASAMI Tomoharu, Daisuke Okajima, Kohsuke Kawaguchi, and MURATA Makoto)
+org.checkerframework:checker-qual | Copyright 2004-present by the Checker Framework developers
+org.jsoup:jsoup | Copyright (c) 2009-2021 Jonathan Hedley
 
-  Copyright (c) 2013, 2022 Oracle and/or its affiliates. All rights reserved.
-  Maven coordinates: https://repo1.maven.org/maven2/org/glassfish/jaxb/jaxb-runtime/4.0.0
+Permission is hereby granted, free of charge, to any person obtaining a 
+copy of this software and associated documentation files (the 
+"Software"), to deal in the Software without restriction, including 
+without limitation the rights to use, copy, modify, merge, publish, 
+distribute, sublicense, and/or sell copies of the Software, and to 
+permit persons to whom the Software is furnished to do so, subject to 
+the following conditions: 
 
-Jakarta XML Binding API
+The above copyright notice and this permission notice shall be included 
+in all copies or substantial portions of the Software. 
 
-  Copyright (c) 2018, 2022 Oracle and/or its affiliates. All rights reserved.
-  Maven coordinates: https://repo1.maven.org/maven2/jakarta/xml/bind/jakarta.xml.bind-api/4.0.0
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS 
+OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF 
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. 
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY 
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, 
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE 
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. 
 
-TXW2 Runtime
-
-  Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
-  Maven coordinates: https://repo1.maven.org/maven2/org/glassfish/jaxb/txw2/2.3.3
-
-istack common utility code runtime
-
-  Copyright (c) 2017 Oracle and/or its affiliates. All rights reserved.
-  Maven coordinates: https://repo1.maven.org/maven2/com/sun/istack/istack-commons-runtime/3.0.11
-
-Jakarta Activation
-
-  Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
-  Maven coordinates: https://repo1.maven.org/maven2/com/sun/activation/jakarta.activation/1.2.2
+END OF MIT LICENSE NOTICES AND INFORMATION
 
 
-NOTICE TEXT
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions
-are met:
+BSD-3-Clause LICENSE
 
-  - Redistributions of source code must retain the above copyright
-    notice, this list of conditions and the following disclaimer.
+The Program includes some or all of the following packages that IBM 
+obtained under the BSD-3-Clause License:
 
-  - Redistributions in binary form must reproduce the above copyright
-    notice, this list of conditions and the following disclaimer in the
-    documentation and/or other materials provided with the distribution.
+com.sun.istack:istack-commons-runtime | Copyright (c) 1997, 2021 Oracle and/or its affiliates
+jakarta.activation:jakarta.activation-api | Copyright (c) 1997  2021 Oracle and/or its affiliates
+jakarta.xml.bind:jakarta.xml.bind-api | Copyright (c) 2017, 2018 Oracle and/or its affiliates
+org.eclipse.angus:angus-activation | Copyright (c) 2021 Oracle and/or its affiliates.
+org.glassfish.jaxb:jaxb-core | Copyright (c) 1997, 2021 Oracle and/or its affiliates.
+org.glassfish.jaxb:jaxb-runtime | Copyright (c) 1997, 2021 Oracle and/or its affiliates.
+org.glassfish.jaxb:txw2 | Copyright (c) 1997, 2021 Oracle and/or its affiliates.
 
-  - Neither the name of the Eclipse Foundation, Inc. nor the names of its
-    contributors may be used to endorse or promote products derived
-    from this software without specific prior written permission.
 
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
-IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
-THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
-PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
-CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
-EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
-PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
-PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
-LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
-NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE
+Redistribution and use in source and binary forms, with or without 
+modification, are permitted provided that the following conditions are 
+met: 
 
-END OF ECLIPSE DISTRIBUTION LICENSE NOTICES AND INFORMATION
+* Redistributions of source code must retain the above copyright notice, 
+  this list of conditions and the following disclaimer. 
+* Redistributions in binary form must reproduce the above copyright 
+  notice, this list of conditions and the following disclaimer in the 
+  documentation and/or other materials provided with the distribution. 
+* Neither the name of the <ORGANIZATION> nor the names of its 
+  contributors may be used to endorse or promote products derived from 
+  this software without specific prior written permission. 
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS 
+IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED 
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A 
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER 
+OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, 
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, 
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR 
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF 
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS 
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
+
+END OF BSD 3-CLAUSE LICENSE NOTICES AND INFORMATION
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+END OF NOTICES AND INFORMATION
 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 END OF NOTICES AND INFORMATION FILE

--- a/lemminx-liberty/pom.xml
+++ b/lemminx-liberty/pom.xml
@@ -4,7 +4,7 @@
     <groupId>io.openliberty.tools</groupId>
     <artifactId>liberty-langserver-lemminx</artifactId>
     <packaging>jar</packaging>
-    <version>1.0-M2-SNAPSHOT</version>
+    <version>1.0-SNAPSHOT</version>
 
     <name>lemminx-liberty</name>
     <url>https://github.com/OpenLiberty/liberty-language-server</url>

--- a/liberty-ls/pom.xml
+++ b/liberty-ls/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>io.openliberty.tools</groupId>
     <artifactId>liberty-langserver</artifactId>
-    <version>1.0-M2-SNAPSHOT</version>
+    <version>1.0-SNAPSHOT</version>
 
     <name>liberty.langserver</name>
     <url>https://openliberty.io/</url>


### PR DESCRIPTION
Need to release `1.0` before merging PR #169 with the latest Eclipse LemMinX version. I changed the version to `1.0-SNAPSHOT` and included the latest NOTICES file.