### PR TITLE
devc pathing

### DIFF
--- a/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/LibertyXSDURIResolver.java
+++ b/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/LibertyXSDURIResolver.java
@@ -91,7 +91,7 @@ public class LibertyXSDURIResolver implements URIResolverExtension, IExternalGra
                 }
             }
         } catch (Exception e) {
-            LOGGER.severe("Error: Unable to deploy server.xsd to LemMinX cache.");
+            LOGGER.severe("Error: Unable to generate the Liberty schema from the target Liberty runtime.");
             e.printStackTrace();
         }
 
@@ -100,7 +100,7 @@ public class LibertyXSDURIResolver implements URIResolverExtension, IExternalGra
             LOGGER.info("Using cached Liberty schema file located at: " + serverXSDFile.toString());
             return serverXSDFile.toUri().toString();
         } catch (Exception e) {
-            LOGGER.severe("CacheResourceManager failed to retrieve or create cache Liberty schema file.");
+            LOGGER.severe("Error: Unable to retrieve default cached Liberty schema file.");
             return null;
         }
     }

--- a/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/LibertyXSDURIResolver.java
+++ b/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/LibertyXSDURIResolver.java
@@ -60,42 +60,49 @@ public class LibertyXSDURIResolver implements URIResolverExtension, IExternalGra
      * @return Path to schema xsd resource as URI.toString()
      */
     public String resolve(String baseLocation, String publicId, String systemId) {
-        if (LibertyUtils.isConfigXMLFile(baseLocation)) {
-            try {
-                String serverXMLUri = URI.create(baseLocation).toString();
-                LibertyWorkspace libertyWorkspace = LibertyProjectsManager.getInstance().getWorkspaceFolder(serverXMLUri);
-
-                if (libertyWorkspace != null) {
-                    //Set workspace properties if not set 
-                    LibertyUtils.getVersion(serverXMLUri);
-                    LibertyUtils.getRuntimeInfo(serverXMLUri);
-
-                    //Check workspace for Liberty installation and generate schema.xsd file
-                    //Return schema URI as String, otherwise use cached schema.xsd file
-                    String serverSchemaUri = null;
-                    if (libertyWorkspace.isLibertyInstalled()) {
-                        Path schemaGenJarPath = LibertyUtils.findFileInWorkspace(libertyWorkspace, Paths.get("bin", "tools", "ws-schemagen.jar"));
-                        if (schemaGenJarPath != null) {
-                            //Generate schema file
-                            serverSchemaUri = generateServerSchemaXsd(libertyWorkspace, schemaGenJarPath);
-                        }
-                    } else if (libertyWorkspace.isContainerAlive()) {
-                        DockerService docker = DockerService.getInstance();
-                        serverSchemaUri = docker.generateServerSchemaXsdFromContainer(libertyWorkspace);
-                    }
-                    if (serverSchemaUri != null && !serverSchemaUri.isEmpty()) {
-                        return serverSchemaUri;
-                    }
-                }
-                Path serverXSDFile = CacheResourcesManager.getResourceCachePath(SERVER_XSD_RESOURCE);
-                LOGGER.info("Using cached Liberty schema file located at: " + serverXSDFile.toString());
-                return serverXSDFile.toUri().toString();
-            } catch (Exception e) {
-                LOGGER.severe("Error: Unable to deploy server.xsd to lemminx cache.");
-                e.printStackTrace();
-            }
+        if (!LibertyUtils.isConfigXMLFile(baseLocation)) {
+            return null;
         }
-        return null;
+
+        try {
+            String serverXMLUri = URI.create(baseLocation).toString();
+            LibertyWorkspace libertyWorkspace = LibertyProjectsManager.getInstance().getWorkspaceFolder(serverXMLUri);
+
+            if (libertyWorkspace != null) {
+                //Set workspace properties if not set 
+                LibertyUtils.getVersion(serverXMLUri);
+                LibertyUtils.getRuntimeInfo(serverXMLUri);
+
+                //Check workspace for Liberty installation and generate schema.xsd file
+                //Return schema URI as String, otherwise use cached schema.xsd file
+                String serverSchemaUri = null;
+                if (libertyWorkspace.isLibertyInstalled()) {
+                    Path schemaGenJarPath = LibertyUtils.findFileInWorkspace(libertyWorkspace, Paths.get("bin", "tools", "ws-schemagen.jar"));
+                    if (schemaGenJarPath != null) {
+                        //Generate schema file
+                        serverSchemaUri = generateServerSchemaXsd(libertyWorkspace, schemaGenJarPath);
+                    }
+                } else if (libertyWorkspace.isContainerAlive()) {
+                    DockerService docker = DockerService.getInstance();
+                    serverSchemaUri = docker.generateServerSchemaXsdFromContainer(libertyWorkspace);
+                }
+                if (serverSchemaUri != null && !serverSchemaUri.isEmpty()) {
+                    return serverSchemaUri;
+                }
+            }
+        } catch (Exception e) {
+            LOGGER.severe("Error: Unable to deploy server.xsd to LemMinX cache.");
+            e.printStackTrace();
+        }
+
+        try {
+            Path serverXSDFile = CacheResourcesManager.getResourceCachePath(SERVER_XSD_RESOURCE);
+            LOGGER.info("Using cached Liberty schema file located at: " + serverXSDFile.toString());
+            return serverXSDFile.toUri().toString();
+        } catch (Exception e) {
+            LOGGER.severe("CacheResourceManager failed to retrieve or create cache Liberty schema file.");
+            return null;
+        }
     }
 
     @Override

--- a/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/services/DockerService.java
+++ b/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/services/DockerService.java
@@ -41,14 +41,10 @@ public class DockerService {
         return instance;
     }
 
-    // saved paths 
-    public static final Path DEFAULT_CONTAINER_WLP_DIR = Paths.get("opt", "ol", "wlp");
-
-    public static final Path DEFAULT_CONTAINER_OL_PROPERTIES_PATH = 
-            DEFAULT_CONTAINER_WLP_DIR.resolve(Paths.get("lib", "versions", "openliberty.properties"));
-    public static final Path DEFAULT_CONTAINER_SCHEMAGEN_JAR_PATH = 
-            DEFAULT_CONTAINER_WLP_DIR.resolve(Paths.get("bin", "tools", "ws-schemagen.jar"));
-
+    // Liberty images use Unix path
+    public static final String DEFAULT_CONTAINER_WLP_DIR = "opt/ol/wlp/";
+    public static final String DEFAULT_CONTAINER_OL_PROPERTIES_PATH = DEFAULT_CONTAINER_WLP_DIR + "lib/versions/openliberty.properties";
+    public static final String DEFAULT_CONTAINER_SCHEMAGEN_JAR_PATH = DEFAULT_CONTAINER_WLP_DIR + "bin/tools/ws-schemagen.jar";
 
     /** ===== Public Methods ===== **/
 
@@ -120,17 +116,18 @@ public class DockerService {
             p.waitFor(DOCKER_TIMEOUT, TimeUnit.SECONDS);
             // After waiting for the process, handle the error case and normal termination.
             if (p.exitValue() != 0) {
-                LOGGER.severe("Error running docker command, return value=" + p.exitValue());
+                LOGGER.severe("Received exit value=" + p.exitValue() + " when running Docker command: " + command);
                 // read messages from standard err
                 char[] d = new char[1023];
                 new InputStreamReader(p.getErrorStream()).read(d);
+                LOGGER.severe("RuntimeException " + new String(d).trim()+" RC="+p.exitValue());
                 throw new RuntimeException(new String(d).trim()+" RC="+p.exitValue());
             }
             result = readStdOut(p);
         } catch (IllegalThreadStateException  e) {
             // the timeout was too short and the docker command has not yet completed. There is no exit value.
             LOGGER.warning("IllegalThreadStateException, message="+e.getMessage());
-            throw new RuntimeException("The docker command did not complete within the timeout period: " + DOCKER_TIMEOUT + " seconds. ");
+            throw new RuntimeException("The Docker command did not complete within the timeout period: " + DOCKER_TIMEOUT + " seconds. ");
         } catch (InterruptedException | IOException e) {
             // If a runtime exception occurred in the server task, log and rethrow
             throw new RuntimeException(e.getMessage());


### PR DESCRIPTION
Addresses the OS pathing portion of #184. 
DockerService uses `Path.resolve` to generate paths to use in a container. This fails on Windows as a Windows path gets built for devc, which are based on Linux.

- Known paths for Docker and Liberty are hardcoded
- Minor additions were added to log messages.

Verified in VS Code on Windows, before and after path changes.
![image](https://github.com/OpenLiberty/liberty-language-server/assets/8934136/9f8b5ace-e11d-4f25-a208-927975df30f7)
