### PR TITLE
Generate schema w/ schemaVersion=1.1, outputVersion=2 

### DIFF
--- a/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/LibertyXSDURIResolver.java
+++ b/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/LibertyXSDURIResolver.java
@@ -140,7 +140,8 @@ public class LibertyXSDURIResolver implements URIResolverExtension, IExternalGra
     
                 LOGGER.info("Generating schema file at: " + xsdDestPath);
     
-                ProcessBuilder pb = new ProcessBuilder("java", "-jar", schemaGenJarPath.toAbsolutePath().toString(), xsdDestPath); //Add locale param here
+                ProcessBuilder pb = new ProcessBuilder("java", "-jar", schemaGenJarPath.toAbsolutePath().toString(), "--schemaVersion=1.1",
+                        "--outputVersion=2", xsdDestPath); // Add locale param here
                 pb.directory(tempDir);
                 pb.redirectErrorStream(true);
                 pb.redirectOutput(new File(tempDir, "schemagen.log"));

--- a/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/services/DockerService.java
+++ b/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/services/DockerService.java
@@ -94,7 +94,9 @@ public class DockerService {
         if (!xsdFile.exists()) {
             // $ java -jar {path to ws-schemagen.jar} {outputFile}
             String containerOutputFileString = "/tmp/" + xsdFileName;
-            String cmd = MessageFormat.format("java -jar {0} {1}", DEFAULT_CONTAINER_SCHEMAGEN_JAR_PATH.toString(), containerOutputFileString);
+            String schemaVersion = "--schemaVersion=1.1";
+            String outputVersion = "--outputVersion=2";
+            String cmd = MessageFormat.format("java -jar {0} {1} {2} {3}", DEFAULT_CONTAINER_SCHEMAGEN_JAR_PATH.toString(), schemaVersion, outputVersion, containerOutputFileString);
 
             // generate xsd file inside container
             dockerExec(libertyWorkspace.getContainerName(), cmd);


### PR DESCRIPTION
Fixes #174 .

Consider this more of a POC than an actual fix.   I didn't pay much attention to the main vs. 1.x branch or reworking on top of the latest fix in 1.x.   But it at least demonstrates to me the XSD changes desired in #174 would be addressed by merging in these options into our schemaGen invocations.