### PR TITLE
Reload featureListGraph and fix NPE

### DIFF
--- a/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/LibertyDocumentLinkParticipant.java
+++ b/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/LibertyDocumentLinkParticipant.java
@@ -43,7 +43,7 @@ public class LibertyDocumentLinkParticipant implements IDocumentLinkParticipant 
         List<DOMNode> nodes = document.getDocumentElement().getChildren();
 
         // collect all <include> nodes that are children of the document element
-        List<DOMNode> includeDomNodes = nodes.stream().filter(n -> n.getNodeName().equals("include"))
+        List<DOMNode> includeDomNodes = nodes.stream().filter(n -> ((n.getNodeName() != null) && n.getNodeName().equals("include")))
                 .collect(Collectors.toList());
 
         for (DOMNode includeNode : includeDomNodes) {

--- a/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/services/FeatureService.java
+++ b/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/services/FeatureService.java
@@ -398,6 +398,30 @@ public class FeatureService {
         return defaultFeatureList;
     }
 
+    public boolean doesGeneratedFeatureListExist(LibertyWorkspace libertyWorkspace) {
+        File tempDir = LibertyUtils.getTempDir(libertyWorkspace);
+
+        //If tempDir is null, issue a warning for the current LibertyWorkspace URI
+        if (tempDir == null) {
+            LOGGER.warning("Unable to locate the feature list for the current Liberty workspace:" + libertyWorkspace.getWorkspaceString());
+            return false;
+        }
+
+        File featureListFile = getGeneratedFeatureListFileLocation(libertyWorkspace, tempDir);
+
+        return featureListFile.exists();
+    }
+
+    public File getGeneratedFeatureListFileLocation(LibertyWorkspace libertyWorkspace, File tempDir) {
+        File featureListFile = new File(tempDir, "featurelist.xml");
+        if (libertyWorkspace.getLibertyVersion()!= null && !libertyWorkspace.getLibertyVersion().isEmpty() &&
+                libertyWorkspace.getLibertyRuntime()!= null && !libertyWorkspace.getLibertyRuntime().isEmpty()) {
+            featureListFile = new File(tempDir, "featurelist-" + libertyWorkspace.getLibertyRuntime() + "-" + libertyWorkspace.getLibertyVersion() + ".xml");
+        }
+
+        return featureListFile;
+    }
+
     /**
      * Generate the featurelist file for a LibertyWorkspace using the ws-featurelist.jar in the corresponding Liberty installation
      * @param libertyWorkspace
@@ -414,11 +438,7 @@ public class FeatureService {
             return null;
         }
 
-        File featureListFile = new File(tempDir, "featurelist.xml");
-        if (libertyWorkspace.getLibertyVersion()!= null && !libertyWorkspace.getLibertyVersion().isEmpty() &&
-                libertyWorkspace.getLibertyRuntime()!= null && !libertyWorkspace.getLibertyRuntime().isEmpty()) {
-            featureListFile = new File(tempDir, "featurelist-" + libertyWorkspace.getLibertyRuntime() + "-" + libertyWorkspace.getLibertyVersion() + ".xml");
-        }
+        File featureListFile = getGeneratedFeatureListFileLocation(libertyWorkspace, tempDir);
 
         try {
             LOGGER.info("Generating feature list file from: " + featurelistJarPath.toString());

--- a/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/services/LibertyWorkspace.java
+++ b/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/services/LibertyWorkspace.java
@@ -238,6 +238,18 @@ public class LibertyWorkspace {
     public FeatureListGraph getFeatureListGraph() {
         FeatureListGraph useFeatureListGraph = this.featureListGraph;
         boolean generateGraph = featureListGraph.isEmpty() || !featureListGraph.getRuntime().equals(getWorkspaceRuntime());
+
+        if (!generateGraph && (isLibertyInstalled || isContainerAlive())) {
+            // Check if FeatureListGraph needs to be reinitialized. This can happen if new features are installed.
+            // The contents of the .libertyls folder are deleted when features are installed, which means we need to 
+            // regenerated it and load the FeatureListGraph.
+            boolean exists = FeatureService.getInstance().doesGeneratedFeatureListExist(this);
+            if (!exists) {
+                generateGraph = true;
+                this.setInstalledFeatureList(new ArrayList<Feature> ()); // clear out cached feature list
+            }
+        }
+
         if (generateGraph) {
             if (isLibertyInstalled || isContainerAlive()) {
                 LOGGER.info("Generating installed features list and storing to cache for workspace " + workspaceFolderURI);


### PR DESCRIPTION
If the generated feature list xml file does not exist, regenerate the feature list and reinitialize the `FeatureListGraph`.

Also fixed a NPE that happened when you start to enter a new config element and have only typed the opening `<`. Our validation code expected the `getNodeName()` to be non-null.