### PR TITLE
Disable config element validation when no featureManager present

### DIFF
--- a/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/services/LibertyWorkspace.java
+++ b/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/services/LibertyWorkspace.java
@@ -264,7 +264,7 @@ public class LibertyWorkspace {
                  useFeatureListGraph = FeatureService.getInstance().getDefaultFeatureList();
             }
             if (!useFeatureListGraph.isEmpty()) {
-                LOGGER.info("Config element validation enabled for workspace: " + workspaceFolderURI);
+                LOGGER.info("Config element validation for missing features enabled for workspace: " + workspaceFolderURI);
             }
         }
         return useFeatureListGraph;

--- a/lemminx-liberty/src/test/java/io/openliberty/LibertyDiagnosticTest.java
+++ b/lemminx-liberty/src/test/java/io/openliberty/LibertyDiagnosticTest.java
@@ -206,12 +206,14 @@ public class LibertyDiagnosticTest {
         FeatureService.getInstance().readFeaturesFromFeatureListFile(new ArrayList<Feature>(), libWorkspace, featureList);
         
         String serverXml = "<server><ssl id=\"\"/></server>";
-        Diagnostic config_for_missing_feature = new Diagnostic();
-        config_for_missing_feature.setRange(r(0, serverXml.indexOf("<ssl"), 0, serverXml.length()-"</server>".length()));
-        config_for_missing_feature.setCode(LibertyDiagnosticParticipant.MISSING_CONFIGURED_FEATURE_CODE);
-        config_for_missing_feature.setMessage(LibertyDiagnosticParticipant.MISSING_CONFIGURED_FEATURE_MESSAGE);
+        // Temporarily disabling config element diagnostics if featureManager element is missing (until issue 230 is addressed)
+        // Diagnostic config_for_missing_feature = new Diagnostic();
+        // config_for_missing_feature.setRange(r(0, serverXml.indexOf("<ssl"), 0, serverXml.length()-"</server>".length()));
+        // config_for_missing_feature.setCode(LibertyDiagnosticParticipant.MISSING_CONFIGURED_FEATURE_CODE);
+        // config_for_missing_feature.setMessage(LibertyDiagnosticParticipant.MISSING_CONFIGURED_FEATURE_MESSAGE);
 
-        XMLAssert.testDiagnosticsFor(serverXml, null, null, serverXMLURI, config_for_missing_feature);
+        // XMLAssert.testDiagnosticsFor(serverXml, null, null, serverXMLURI, config_for_missing_feature);
+        XMLAssert.testDiagnosticsFor(serverXml, null, null, serverXMLURI); // expect no diagnostic for this scenario right now
     }
 
     @Test


### PR DESCRIPTION
Related to #230 

Until we address 230, temporarily disable the config element validation for missing features when no `<featureManager>` element is found in the current xml file.