### PR TITLE
Use default cached feature list if Workspace cannot be found

### DIFF
--- a/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/LibertyDiagnosticParticipant.java
+++ b/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/LibertyDiagnosticParticipant.java
@@ -79,7 +79,10 @@ public class LibertyDiagnosticParticipant implements IDiagnosticsParticipant {
         includedFeatures = new HashSet<>();
         featureManagerPresent = false;
         LibertyWorkspace workspace = LibertyProjectsManager.getInstance().getWorkspaceFolder(domDocument.getDocumentURI());
-        FeatureListGraph featureGraph = (workspace == null) ? new FeatureListGraph() : workspace.getFeatureListGraph();
+        if (workspace == null) {
+            LOGGER.warning("Could not get workspace, using default cached feature list");
+        }
+        FeatureListGraph featureGraph = (workspace == null) ? FeatureService.getInstance().getDefaultFeatureList() : workspace.getFeatureListGraph();
         for (DOMNode node : nodes) {
             String nodeName = node.getNodeName();
             if (LibertyConstants.FEATURE_MANAGER_ELEMENT.equals(nodeName)) {

--- a/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/codeactions/AddFeature.java
+++ b/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/codeactions/AddFeature.java
@@ -65,12 +65,15 @@ public class AddFeature implements ICodeActionParticipant {
         TextDocument textDocument = document.getTextDocument();
 
         LibertyWorkspace ws = LibertyProjectsManager.getInstance().getWorkspaceFolder(document.getDocumentURI());    
+        FeatureListGraph featureGraph = null;
         if (ws == null) {
-            LOGGER.warning("Could not add quick fix for missing feature because could not find Liberty workspace for document: "+document.getDocumentURI());
-            return;
+            LOGGER.warning("Could not get workspace for: "+document.getDocumentURI() + ". Using cached feature list for quick fix.");
+            featureGraph = FeatureService.getInstance().getDefaultFeatureList();
+        } else {
+            featureGraph = ws.getFeatureListGraph();
         }
 
-        FeatureListNode flNode = ws.getFeatureListGraph().get(diagnostic.getSource());
+        FeatureListNode flNode = featureGraph.get(diagnostic.getSource());
         if (flNode == null) {
             LOGGER.warning("Could not add quick fix for missing feature for config element due to missing information in the feature list: "+diagnostic.getSource());
             return;


### PR DESCRIPTION
For https://github.com/OpenLiberty/liberty-tools-intellij/issues/546

Change default behavior to use cached feature list if Workspace cannot be found.

IntelliJ screenshots after this fix:
<img width="964" alt="image" src="https://github.com/OpenLiberty/liberty-language-server/assets/689163/5d959f5e-1a6d-42ee-96cb-2e9ff1b514d2">
<img width="567" alt="image" src="https://github.com/OpenLiberty/liberty-language-server/assets/689163/19ddd321-c16c-47d4-b29b-96aae4067cb2">
