### PR TITLE
Ensure parameters are in URI format

### DIFF
--- a/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/util/LibertyUtils.java
+++ b/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/util/LibertyUtils.java
@@ -65,16 +65,12 @@ public class LibertyUtils {
      * If the rootPath is not null, only XML files that that do not fall into category 1 or 2 and are not located in a target/build 
      * directory will be checked for a <server> root element. The rootPath is non-null when called from getXmlFilesWithServerRootInDirectory method.
      * 
-     * @param rootPath - String path of root directory for the filePath - only consider the portion of the filePath after the rootPath
-     * @param filePath - String path of the XML file to check
+     * @param rootPath - String path of root directory for the filePath in URI format - only consider the portion of the filePath after the rootPath
+     * @param filePath - String path of the XML file to check in URI format
      * @return boolean - true if the XML file is a Liberty config file, false otherwise
      */
     public static boolean isConfigXMLFile(String rootPath, String filePath) {
         String pathToCheck = rootPath == null ? filePath : filePath.substring(rootPath.length());
-
-        if (File.separator.equals("\\")) {
-            pathToCheck = pathToCheck.replace("\\", "/");
-        }
 
         // if path contains one of the pre-defined Liberty config dirs or ends with /server.xml, 
         // just return true without checking for server root
@@ -152,11 +148,11 @@ public class LibertyUtils {
      */
     public static List<Path> getXmlFilesWithServerRootInDirectory(Path dir) throws IOException {
         List<Path> serverRootXmlFiles = new ArrayList<Path>();
-        String rootPath = dir.toString();
+        String rootPath = dir.toFile().toURI().toString();
 
         List<Path> xmlFiles = findFilesEndsWithInDirectory(dir, ".xml");
         for (Path nextXmlFile : xmlFiles) {
-            if (isConfigXMLFile(rootPath, nextXmlFile.toString())) {
+            if (isConfigXMLFile(rootPath, nextXmlFile.toFile().toURI().toString())) {
                 serverRootXmlFiles.add(nextXmlFile);
             }
         }       
@@ -174,7 +170,7 @@ public class LibertyUtils {
      */
     public static List<Path> findFilesEndsWithInDirectory(Path dir, String nameOrExtension) throws IOException {
         List<Path> matchingFiles = Files.walk(dir)
-                .filter(p -> (Files.isRegularFile(p) && p.toFile().getName().endsWith(nameOrExtension)))
+                .filter(p -> (Files.isRegularFile(p) && p.toFile().getName().toLowerCase().endsWith(nameOrExtension)))
                 .collect(Collectors.toList());
 
         return matchingFiles;

--- a/lemminx-liberty/src/test/java/io/openliberty/LibertyWorkspaceTest.java
+++ b/lemminx-liberty/src/test/java/io/openliberty/LibertyWorkspaceTest.java
@@ -33,20 +33,36 @@ public class LibertyWorkspaceTest {
     }
 
     @Test
+    public void testConfigDropinsDefaults() throws IOException {
+        File mockXML = new File("src/test/resources/configDropins/defaults/my.xml");
+        URI filePathURI = mockXML.toURI();
+
+        assertTrue(LibertyUtils.isConfigXMLFile(filePathURI.toString()));
+
+    }
+
+    @Test
     public void testBackslashConfigDetection() throws IOException {
         // run test on Windows
         if (File.separator.equals("/")) {
             return;
         }
 
-        File mockXML = new File("src/test/resources/configDropins/defaults/my.xml");
+        File mockXML = new File("src/test/resources/sample/custom_server.xml");
         String filePathString = mockXML.getCanonicalPath();
         URI filePathURI = mockXML.toURI();
 
-        assertTrue(LibertyUtils.isConfigXMLFile(filePathString));
         assertTrue(LibertyUtils.isConfigXMLFile(filePathURI.toString()));
+
+        // method expects URI formatted string and so should fail on Windows
+        boolean test1 = LibertyUtils.isConfigXMLFile(filePathString);
+        assertFalse(test1);
+
         // mock replacement
         filePathString = filePathString.replace("\\", "/");
-        assertTrue(LibertyUtils.isConfigXMLFile(filePathString));
+        // method expects URI formatted string and so should fail on Windows
+        boolean test2 = LibertyUtils.isConfigXMLFile(filePathString);
+        assertFalse(test2);
+
     }
 }

--- a/lemminx-liberty/src/test/java/io/openliberty/LibertyWorkspaceTest.java
+++ b/lemminx-liberty/src/test/java/io/openliberty/LibertyWorkspaceTest.java
@@ -57,12 +57,5 @@ public class LibertyWorkspaceTest {
         // method expects URI formatted string and so should fail on Windows
         boolean test1 = LibertyUtils.isConfigXMLFile(filePathString);
         assertFalse(test1);
-
-        // mock replacement
-        filePathString = filePathString.replace("\\", "/");
-        // method expects URI formatted string and so should fail on Windows
-        boolean test2 = LibertyUtils.isConfigXMLFile(filePathString);
-        assertFalse(test2);
-
     }
 }


### PR DESCRIPTION
Fix Windows problem where the `LibertyUtils.getXmlFilesWithServerRootInDirectory(workspacePath)` was getting an exception because the path passed into `hasServerRoot` was not in URI format.