### PR TITLE
Initial Hover/Completion support for server.xml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
           repository: OpenLiberty/ci.common
           path: ci.common
       - name: Build ci.common
-        run: mvn clean install
+        run: ./mvnw clean install -f ci.common -DskipTests
       - name: Build LCLS
         working-directory: ./liberty-ls
         run: ./mvnw clean package -ntp -DskipTests

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: '**'
   pull_request:
-    branches: [main]
+    branches: [main, 2q2024]
 
 jobs:
   liberty-config-language-server:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: '**'
   pull_request:
-    branches: [main, 2q2024]
+    branches: [2q2024]
 
 jobs:
   liberty-config-language-server:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,13 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: 17
+      - name: Checkout ci.common
+        uses: actions/checkout@v3
+        with:
+          repository: OpenLiberty/ci.common
+          path: ci.common
+      - name: Build ci.common
+        run: mvn clean install
       - name: Build LCLS
         working-directory: ./liberty-ls
         run: ./mvnw clean package -ntp -DskipTests

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: '**'
   pull_request:
-    branches: [main, 2q2024]
+    branches: [main]
 
 jobs:
   liberty-config-language-server:
@@ -23,8 +23,9 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: OpenLiberty/ci.common
-          path: ci.common
+          path: liberty-ls/ci.common
       - name: Build ci.common
+        working-directory: ./liberty-ls
         run: ./mvnw clean install -f ci.common -DskipTests
       - name: Build LCLS
         working-directory: ./liberty-ls

--- a/liberty-ls/pom.xml
+++ b/liberty-ls/pom.xml
@@ -24,21 +24,6 @@
         <tag>HEAD</tag>
     </scm>
 
-    <repositories>
-        <!-- Configure Sonatype OSS Maven snapshots repository -->
-        <repository>
-            <id>sonatype-nexus-snapshots</id>
-            <name>Sonatype Nexus Snapshots</name>
-            <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-            <releases>
-                <enabled>false</enabled>
-            </releases>
-        </repository>
-    </repositories>
-
     <distributionManagement>
         <snapshotRepository>
             <id>sonatype-nexus-snapshots</id>

--- a/liberty-ls/pom.xml
+++ b/liberty-ls/pom.xml
@@ -24,6 +24,21 @@
         <tag>HEAD</tag>
     </scm>
 
+    <repositories>
+        <!-- Configure Sonatype OSS Maven snapshots repository -->
+        <repository>
+            <id>sonatype-nexus-snapshots</id>
+            <name>Sonatype Nexus Snapshots</name>
+            <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+        </repository>
+    </repositories>
+
     <distributionManagement>
         <snapshotRepository>
             <id>sonatype-nexus-snapshots</id>

--- a/liberty-ls/src/main/java/io/openliberty/tools/langserver/LibertyConfigFileManager.java
+++ b/liberty-ls/src/main/java/io/openliberty/tools/langserver/LibertyConfigFileManager.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2023 IBM Corporation and others.
+* Copyright (c) 2024 IBM Corporation and others.
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License v. 2.0 which is available at

--- a/liberty-ls/src/main/java/io/openliberty/tools/langserver/LibertyConfigFileManager.java
+++ b/liberty-ls/src/main/java/io/openliberty/tools/langserver/LibertyConfigFileManager.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2024 IBM Corporation and others.
+* Copyright (c) 2023, 2024 IBM Corporation and others.
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License v. 2.0 which is available at

--- a/liberty-ls/src/main/java/io/openliberty/tools/langserver/LibertyConfigFileManager.java
+++ b/liberty-ls/src/main/java/io/openliberty/tools/langserver/LibertyConfigFileManager.java
@@ -139,13 +139,18 @@ public class LibertyConfigFileManager {
                 customBootstrapFiles.contains(filePath);
     }
 
+    // TODO: similar treatment to server.env and bootstrap.properties. Improve during liberty-plugin-config.xml enhancement
+    public static boolean isServerXml(LibertyTextDocument textDocument) {
+        return textDocument.getUri().endsWith("server.xml");
+    }
+
     /**
-     * Returns true if valid server.env or bootstrap.properties file defined by defaults or custom settings
+     * Returns true if valid server.env, bootstrap.properties, or server.xml file defined by defaults or custom settings
      * @param tdi
      * @return
      */
     public static boolean isConfigFile(LibertyTextDocument tdi) {
-        return isServerEnvFile(tdi) || isBootstrapPropertiesFile(tdi);
+        return isServerEnvFile(tdi) || isBootstrapPropertiesFile(tdi) || isServerXml(tdi);
     }
 
     /**

--- a/liberty-ls/src/main/java/io/openliberty/tools/langserver/LibertyWorkspaceService.java
+++ b/liberty-ls/src/main/java/io/openliberty/tools/langserver/LibertyWorkspaceService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2020, 2023 IBM Corporation and others.
+* Copyright (c) 2020, 2024 IBM Corporation and others.
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License v. 2.0 which is available at
@@ -18,8 +18,6 @@ import org.eclipse.lsp4j.DidChangeConfigurationParams;
 import org.eclipse.lsp4j.DidChangeWatchedFilesParams;
 import org.eclipse.lsp4j.FileEvent;
 import org.eclipse.lsp4j.services.WorkspaceService;
-
-import io.openliberty.tools.langserver.utils.ServerConfigUtil;
 
 public class LibertyWorkspaceService implements WorkspaceService {
 
@@ -41,9 +39,6 @@ public class LibertyWorkspaceService implements WorkspaceService {
             String uri = change.getUri();
             if (uri.endsWith(LibertyConfigFileManager.LIBERTY_PLUGIN_CONFIG_XML)) {
                 LibertyConfigFileManager.processLibertyPluginConfigXml(uri);
-            } else if (uri.endsWith(".xml")) {
-                ServerConfigUtil.requestParseXml(uri);
-                LOGGER.warning("parsed document and found vars: " + ServerConfigUtil.getProperties());
             }
         }
     }

--- a/liberty-ls/src/main/java/io/openliberty/tools/langserver/completion/LibertyPropertiesCompletionProvider.java
+++ b/liberty-ls/src/main/java/io/openliberty/tools/langserver/completion/LibertyPropertiesCompletionProvider.java
@@ -1,6 +1,6 @@
 
 /*******************************************************************************
-* Copyright (c) 2020, 2022 IBM Corporation and others.
+* Copyright (c) 2020, 2024 IBM Corporation and others.
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License v. 2.0 which is available at
@@ -19,6 +19,7 @@ import java.util.concurrent.CompletableFuture;
 import org.eclipse.lsp4j.CompletionItem;
 import org.eclipse.lsp4j.Position;
 
+import io.openliberty.tools.langserver.LibertyConfigFileManager;
 import io.openliberty.tools.langserver.ls.LibertyTextDocument;
 import io.openliberty.tools.langserver.model.envVar.ExpansionVariableInstance;
 import io.openliberty.tools.langserver.model.propertiesfile.PropertiesEntryInstance;
@@ -33,7 +34,7 @@ public class LibertyPropertiesCompletionProvider {
 
     public CompletableFuture<List<CompletionItem>> getCompletions(Position position) {
         String line = new ParserFileHelperUtil().getLine(textDocumentItem, position);
-        if (textDocumentItem.isServerXml()) {
+        if (LibertyConfigFileManager.isServerXml(textDocumentItem)) {
             return new ExpansionVariableInstance(line, textDocumentItem).getCompletions(position);
         }
         return new PropertiesEntryInstance(line, textDocumentItem).getCompletions(position);

--- a/liberty-ls/src/main/java/io/openliberty/tools/langserver/completion/LibertyPropertiesCompletionProvider.java
+++ b/liberty-ls/src/main/java/io/openliberty/tools/langserver/completion/LibertyPropertiesCompletionProvider.java
@@ -20,6 +20,7 @@ import org.eclipse.lsp4j.CompletionItem;
 import org.eclipse.lsp4j.Position;
 
 import io.openliberty.tools.langserver.ls.LibertyTextDocument;
+import io.openliberty.tools.langserver.model.envVar.ExpansionVariableInstance;
 import io.openliberty.tools.langserver.model.propertiesfile.PropertiesEntryInstance;
 import io.openliberty.tools.langserver.utils.ParserFileHelperUtil;
 
@@ -32,6 +33,9 @@ public class LibertyPropertiesCompletionProvider {
 
     public CompletableFuture<List<CompletionItem>> getCompletions(Position position) {
         String line = new ParserFileHelperUtil().getLine(textDocumentItem, position);
+        if (textDocumentItem.isServerXml()) {
+            return new ExpansionVariableInstance(line, textDocumentItem).getCompletions(position);
+        }
         return new PropertiesEntryInstance(line, textDocumentItem).getCompletions(position);
     }
 }

--- a/liberty-ls/src/main/java/io/openliberty/tools/langserver/diagnostic/DiagnosticRunner.java
+++ b/liberty-ls/src/main/java/io/openliberty/tools/langserver/diagnostic/DiagnosticRunner.java
@@ -26,6 +26,7 @@ import org.eclipse.lsp4j.PublishDiagnosticsParams;
 import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.TextDocumentItem;
 
+import io.openliberty.tools.langserver.LibertyConfigFileManager;
 import io.openliberty.tools.langserver.LibertyLanguageServer;
 import io.openliberty.tools.langserver.ls.LibertyTextDocument;
 import io.openliberty.tools.langserver.utils.PropertiesValidationResult;
@@ -56,10 +57,8 @@ public class DiagnosticRunner {
         CompletableFuture.runAsync(() -> {
             LibertyTextDocument openedDocument = libertyLanguageServer.getTextDocumentService().getOpenedDocument(uri);
             List<Diagnostic> diagnostics = new ArrayList<>();
-            LOGGER.warning("About to calculate diagnostics");
             Map<String, PropertiesValidationResult> propertiesErrors = libertyPropertiesDiagnosticService.compute(text, openedDocument);
-            if (openedDocument.isServerXml()) {
-                LOGGER.warning("Running server.xml diagnostics");
+            if (LibertyConfigFileManager.isServerXml(openedDocument)) {
                 Diagnostic testDiagnostic = new Diagnostic(new Range(new Position(0, 0), new Position(0,1)), "This is our proof of concept diagnostic.");
                 diagnostics.add(testDiagnostic);
             }

--- a/liberty-ls/src/main/java/io/openliberty/tools/langserver/hover/LibertyPropertiesHoverProvider.java
+++ b/liberty-ls/src/main/java/io/openliberty/tools/langserver/hover/LibertyPropertiesHoverProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2022, 2023 IBM Corporation and others.
+* Copyright (c) 2022, 2024 IBM Corporation and others.
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License v. 2.0 which is available at

--- a/liberty-ls/src/main/java/io/openliberty/tools/langserver/hover/LibertyPropertiesHoverProvider.java
+++ b/liberty-ls/src/main/java/io/openliberty/tools/langserver/hover/LibertyPropertiesHoverProvider.java
@@ -32,13 +32,14 @@ public class LibertyPropertiesHoverProvider {
 
     public CompletableFuture<Hover> getHover(Position position) {
         String entryLine = new ParserFileHelperUtil().getLine(textDocumentItem, position);
-        if (textDocumentItem.isServerXml()) {
-            return new ExpansionVariableInstance(entryLine, textDocumentItem).getHover(position);
-        }
         if (!LibertyConfigFileManager.isConfigFile(textDocumentItem)) {
             // return empty Hover if not a server config file
             return CompletableFuture.completedFuture(new Hover(new MarkupContent("plaintext", "")));
         }
+        if (LibertyConfigFileManager.isServerXml(textDocumentItem)) {
+            return new ExpansionVariableInstance(entryLine, textDocumentItem).getHover(position);
+        }
+
         return new PropertiesEntryInstance(entryLine, textDocumentItem).getHover(position);
     }
 }

--- a/liberty-ls/src/main/java/io/openliberty/tools/langserver/hover/LibertyPropertiesHoverProvider.java
+++ b/liberty-ls/src/main/java/io/openliberty/tools/langserver/hover/LibertyPropertiesHoverProvider.java
@@ -27,7 +27,6 @@ public class LibertyPropertiesHoverProvider {
     private LibertyTextDocument textDocumentItem;
 
     public LibertyPropertiesHoverProvider(LibertyTextDocument textDocumentItem) {
-        // LOGGER.warning("The hover provider has been initialized");
         this.textDocumentItem = textDocumentItem;
     }
 

--- a/liberty-ls/src/main/java/io/openliberty/tools/langserver/hover/LibertyPropertiesHoverProvider.java
+++ b/liberty-ls/src/main/java/io/openliberty/tools/langserver/hover/LibertyPropertiesHoverProvider.java
@@ -10,6 +10,7 @@
 package io.openliberty.tools.langserver.hover;
 
 import java.util.concurrent.CompletableFuture;
+import java.util.logging.Logger;
 
 import org.eclipse.lsp4j.Hover;
 import org.eclipse.lsp4j.MarkupContent;
@@ -17,22 +18,28 @@ import org.eclipse.lsp4j.Position;
 
 import io.openliberty.tools.langserver.LibertyConfigFileManager;
 import io.openliberty.tools.langserver.ls.LibertyTextDocument;
+import io.openliberty.tools.langserver.model.envVar.ExpansionVariableInstance;
 import io.openliberty.tools.langserver.model.propertiesfile.PropertiesEntryInstance;
 import io.openliberty.tools.langserver.utils.ParserFileHelperUtil;
 
 public class LibertyPropertiesHoverProvider {
+    private static final Logger LOGGER = Logger.getLogger(LibertyPropertiesHoverProvider.class.getName());
     private LibertyTextDocument textDocumentItem;
 
     public LibertyPropertiesHoverProvider(LibertyTextDocument textDocumentItem) {
+        // LOGGER.warning("The hover provider has been initialized");
         this.textDocumentItem = textDocumentItem;
     }
 
     public CompletableFuture<Hover> getHover(Position position) {
+        String entryLine = new ParserFileHelperUtil().getLine(textDocumentItem, position);
+        if (textDocumentItem.isServerXml()) {
+            return new ExpansionVariableInstance(entryLine, textDocumentItem).getHover(position);
+        }
         if (!LibertyConfigFileManager.isConfigFile(textDocumentItem)) {
             // return empty Hover if not a server config file
             return CompletableFuture.completedFuture(new Hover(new MarkupContent("plaintext", "")));
         }
-        String entryLine = new ParserFileHelperUtil().getLine(textDocumentItem, position);
         return new PropertiesEntryInstance(entryLine, textDocumentItem).getHover(position);
     }
 }

--- a/liberty-ls/src/main/java/io/openliberty/tools/langserver/ls/LibertyTextDocument.java
+++ b/liberty-ls/src/main/java/io/openliberty/tools/langserver/ls/LibertyTextDocument.java
@@ -62,10 +62,4 @@ public class LibertyTextDocument extends TextDocumentItem {
             LOGGER.info(last.getText());
         }
     }
-
-    // TODO: improve this -- likely expand to isConfigFile
-    public boolean isServerXml() {
-        return this.getUri().endsWith("server.xml");
-    }
-
 }

--- a/liberty-ls/src/main/java/io/openliberty/tools/langserver/model/envVar/ExpansionVariableInstance.java
+++ b/liberty-ls/src/main/java/io/openliberty/tools/langserver/model/envVar/ExpansionVariableInstance.java
@@ -65,8 +65,8 @@ public class ExpansionVariableInstance {
     }
 
     public CompletableFuture<List<CompletionItem>> getCompletions(Position position) {
-        int startIndex = this.entryLine.lastIndexOf("${");
         int cursorIndex = position.getCharacter();
+        int startIndex = this.entryLine.substring(0, cursorIndex).lastIndexOf("${");
         if (startIndex == -1 || cursorIndex < startIndex + 2 || documentProperties.isEmpty()) {
             return CompletableFuture.completedFuture(Collections.emptyList());
         }
@@ -83,6 +83,9 @@ public class ExpansionVariableInstance {
         };
 
         List<CompletionItem> completionList = documentProperties.keySet().stream().map(s -> s.toString()).filter(filter).map(s -> new CompletionItem(s)).collect(Collectors.toList());
+        for (CompletionItem item : completionList) {
+            item.setInsertText(item.getLabel() + "}");
+        }
         return CompletableFuture.completedFuture(completionList);
     }
 }

--- a/liberty-ls/src/main/java/io/openliberty/tools/langserver/model/envVar/ExpansionVariableInstance.java
+++ b/liberty-ls/src/main/java/io/openliberty/tools/langserver/model/envVar/ExpansionVariableInstance.java
@@ -74,7 +74,6 @@ public class ExpansionVariableInstance {
         LOGGER.info("The list of pre-filtered completable items are: " + documentProperties.keySet().toString());
         String query = this.entryLine.substring(startIndex + 2, cursorIndex);
 
-        // predicate loaned from Messages.java
         Predicate<String> filter = s -> {
             for (int i = s.length() - query.length(); i >= 0; --i) {
                 if (s.regionMatches(true, i, query, 0, query.length()))

--- a/liberty-ls/src/main/java/io/openliberty/tools/langserver/model/envVar/ExpansionVariableInstance.java
+++ b/liberty-ls/src/main/java/io/openliberty/tools/langserver/model/envVar/ExpansionVariableInstance.java
@@ -84,8 +84,14 @@ public class ExpansionVariableInstance {
         List<CompletionItem> completionList = documentProperties.keySet().stream()
                 .map(s -> s.toString()).filter(filter)
                 .map(s -> new CompletionItem(s)).collect(Collectors.toList());
-        for (CompletionItem item : completionList) {
-            item.setInsertText(item.getLabel() + "}");
+
+        String entryRemainder = this.entryLine.substring(cursorIndex);
+        int open = entryRemainder.indexOf("${");
+        int close = entryRemainder.indexOf("}");
+        if (close == -1 || open != -1) {
+            for (CompletionItem item : completionList) {
+                item.setInsertText(item.getLabel() + "}");
+            }
         }
         return CompletableFuture.completedFuture(completionList);
     }

--- a/liberty-ls/src/main/java/io/openliberty/tools/langserver/model/envVar/ExpansionVariableInstance.java
+++ b/liberty-ls/src/main/java/io/openliberty/tools/langserver/model/envVar/ExpansionVariableInstance.java
@@ -88,7 +88,7 @@ public class ExpansionVariableInstance {
         String entryRemainder = this.entryLine.substring(cursorIndex);
         int open = entryRemainder.indexOf("${");
         int close = entryRemainder.indexOf("}");
-        if (close == -1 || open != -1) {
+        if (close == -1 || (close > open && open != -1)) {
             for (CompletionItem item : completionList) {
                 item.setInsertText(item.getLabel() + "}");
             }

--- a/liberty-ls/src/main/java/io/openliberty/tools/langserver/model/envVar/ExpansionVariableInstance.java
+++ b/liberty-ls/src/main/java/io/openliberty/tools/langserver/model/envVar/ExpansionVariableInstance.java
@@ -88,7 +88,7 @@ public class ExpansionVariableInstance {
         String entryRemainder = this.entryLine.substring(cursorIndex);
         int open = entryRemainder.indexOf("${");
         int close = entryRemainder.indexOf("}");
-        if (close == -1 || (close > open && open != -1)) {
+        if (close == -1 || (open != -1 && open < close)) {
             for (CompletionItem item : completionList) {
                 item.setInsertText(item.getLabel() + "}");
             }

--- a/liberty-ls/src/main/java/io/openliberty/tools/langserver/model/envVar/ExpansionVariableInstance.java
+++ b/liberty-ls/src/main/java/io/openliberty/tools/langserver/model/envVar/ExpansionVariableInstance.java
@@ -1,0 +1,89 @@
+/*******************************************************************************
+* Copyright (c) 2024 IBM Corporation and others.
+*
+* This program and the accompanying materials are made available under the
+* terms of the Eclipse Public License v. 2.0 which is available at
+* http://www.eclipse.org/legal/epl-2.0.
+*
+* SPDX-License-Identifier: EPL-2.0
+*******************************************************************************/
+package io.openliberty.tools.langserver.model.envVar;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Properties;
+import java.util.concurrent.CompletableFuture;
+import java.util.logging.Logger;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.eclipse.lsp4j.CompletionItem;
+import org.eclipse.lsp4j.Hover;
+import org.eclipse.lsp4j.MarkupContent;
+import org.eclipse.lsp4j.Position;
+
+import io.openliberty.tools.langserver.ls.LibertyTextDocument;
+import io.openliberty.tools.langserver.utils.ServerConfigUtil;
+
+public class ExpansionVariableInstance {
+    // regex for "$word" or "${...}" respectively
+    private Pattern pattern = Pattern.compile("\\$([\\w]+)|\\$\\{([^}]+)\\}");
+    private final Logger LOGGER = Logger.getLogger(ExpansionVariableInstance.class.getName());
+    private Properties documentProperties;
+    private String entryLine;
+
+    public ExpansionVariableInstance(String entryLine, LibertyTextDocument textDocumentItem) {
+        ServerConfigUtil.requestParseXml(textDocumentItem.getUri());
+        this.documentProperties = ServerConfigUtil.getProperties();
+        this.entryLine = entryLine;
+    }
+
+    public String captureProperty(String input, int charOffset) {
+        Matcher matcher = pattern.matcher(input);
+        while (matcher.find()) {
+            int startIndex = matcher.start();
+            int endIndex = matcher.end();
+            if (charOffset >= startIndex && charOffset <= endIndex) {
+                // return match for "$word"
+                if (matcher.group(1) != null) {
+                    return matcher.group(1);
+                }
+                // return match for "${...}"
+                else if (matcher.group(2) != null) {
+                    return matcher.group(2);
+                }
+            }
+        }
+        return "";
+    }
+
+    public CompletableFuture<Hover> getHover(Position position) {
+        String propertyString = captureProperty(this.entryLine, position.getCharacter());
+        LOGGER.warning("The captured word is: " + propertyString);
+        if (documentProperties.containsKey(propertyString)) {
+            return CompletableFuture.completedFuture(new Hover(new MarkupContent("plaintext", documentProperties.getProperty(propertyString))));
+        }
+        return CompletableFuture.completedFuture(new Hover(new MarkupContent("plaintext", "")));
+    }
+
+    public CompletableFuture<List<CompletionItem>> getCompletions(Position position) {
+        // return list of variables
+        LOGGER.warning("Completions is revealing: " + documentProperties.keySet().toString());
+        return CompletableFuture.completedFuture(Collections.emptyList());
+    }
+
+    /**
+     * Loaned from Messages.java
+     */
+    public List<String> getMatchingKeys(String query, LibertyTextDocument textDocument) {
+        // remove completion results that don't contain the query string (case-insensitive search)
+        // Predicate<String> filter = s -> {
+        //     for (int i = s.length() - query.length(); i >= 0; --i) {
+        //         if (s.regionMatches(true, i, query, 0, query.length()))
+        //             return false;
+        //     }
+        //     return true;
+        // };
+        return Collections.emptyList();
+    }
+}

--- a/liberty-ls/src/main/java/io/openliberty/tools/langserver/model/envVar/ExpansionVariableInstance.java
+++ b/liberty-ls/src/main/java/io/openliberty/tools/langserver/model/envVar/ExpansionVariableInstance.java
@@ -26,8 +26,8 @@ import io.openliberty.tools.langserver.ls.LibertyTextDocument;
 import io.openliberty.tools.langserver.utils.ServerConfigUtil;
 
 public class ExpansionVariableInstance {
-    // regex for "$word" or "${...}" respectively
-    private Pattern pattern = Pattern.compile("\\$([\\w]+)|\\$\\{([^}]+)\\}");
+    // regex for "${...}"
+    private Pattern pattern = Pattern.compile("\\$\\{([^}]+)\\}");
     private final Logger LOGGER = Logger.getLogger(ExpansionVariableInstance.class.getName());
     private Properties documentProperties;
     private String entryLine;
@@ -41,17 +41,8 @@ public class ExpansionVariableInstance {
     public String captureProperty(String input, int charOffset) {
         Matcher matcher = pattern.matcher(input);
         while (matcher.find()) {
-            int startIndex = matcher.start();
-            int endIndex = matcher.end();
-            if (charOffset >= startIndex && charOffset <= endIndex) {
-                // return match for "$word"
-                if (matcher.group(1) != null) {
-                    return matcher.group(1);
-                }
-                // return match for "${...}"
-                else if (matcher.group(2) != null) {
-                    return matcher.group(2);
-                }
+            if (charOffset >= matcher.start() && charOffset <= matcher.end()) {
+                return matcher.group(1);
             }
         }
         return "";

--- a/liberty-ls/src/main/java/io/openliberty/tools/langserver/utils/ServerConfigUtil.java
+++ b/liberty-ls/src/main/java/io/openliberty/tools/langserver/utils/ServerConfigUtil.java
@@ -1,3 +1,15 @@
+/*******************************************************************************
+* Copyright (c) 2024 IBM Corporation and others.
+*
+* This program and the accompanying materials are made available under the
+* terms of the Eclipse Public License v. 2.0 which is available at
+* http://www.eclipse.org/legal/epl-2.0.
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*     IBM Corporation - initial API and implementation
+*******************************************************************************/
 package io.openliberty.tools.langserver.utils;
 
 import java.io.File;
@@ -17,21 +29,27 @@ import io.openliberty.tools.langserver.CommonLogger;
 public class ServerConfigUtil {
     private final static Logger LOGGER = Logger.getLogger(ServerConfigUtil.class.getName());
     private static CommonLogger log = CommonLogger.getInstance(LOGGER);
-    private static ServerConfigDocument configDocument = new ServerConfigDocument(log);
 
-    public static void requestParseXml(String uri) {
+    public static ServerConfigDocument parseXmlRequest(String uri) {
+        // TODO: configDocument as an enhancement will need to be workspace aware
+        ServerConfigDocument configDocument = new ServerConfigDocument(log);
         Document doc;
         try {
             doc = configDocument.parseDocument(new File(URI.create(uri)));
             configDocument.parseVariablesForBothValues(doc);
+            return configDocument;
         } catch (XPathExpressionException | IOException e) {
-            // TODO Auto-generated catch block
             LOGGER.warning("Error trying to parse document: " + uri);
             e.printStackTrace();
         }
+        return null;
     }
 
-    public static Properties getProperties() {
+    public static Properties parseDocumentAndGetProperties(String uri) {
+        ServerConfigDocument configDocument = parseXmlRequest(uri);
+        if (configDocument == null) {
+            return new Properties();
+        }
         return configDocument.getProperties();
     }
 }

--- a/liberty-ls/src/main/java/io/openliberty/tools/langserver/utils/ServerConfigUtil.java
+++ b/liberty-ls/src/main/java/io/openliberty/tools/langserver/utils/ServerConfigUtil.java
@@ -9,24 +9,22 @@ import java.util.logging.Logger;
 import javax.xml.xpath.XPathExpressionException;
 
 import org.w3c.dom.Document;
-import org.xml.sax.SAXException;
 
 import io.openliberty.tools.common.plugins.config.ServerConfigDocument;
 import io.openliberty.tools.langserver.CommonLogger;
 
 //TODO: rename class to relate to ci.common
 public class ServerConfigUtil {
-    
-    private static final Logger LOGGER = Logger.getLogger(ServerConfigUtil.class.getName());
-    static CommonLogger log = CommonLogger.getInstance(LOGGER);
+    private final static Logger LOGGER = Logger.getLogger(ServerConfigUtil.class.getName());
+    private static CommonLogger log = CommonLogger.getInstance(LOGGER);
+    private static ServerConfigDocument configDocument = new ServerConfigDocument(log);
 
     // need method to request ci.common to parse vars from an xml file
     public static void requestParseXml(String uri) {
-        ServerConfigDocument.setLogger(log);
         Document doc;
         try {
-            doc = ServerConfigDocument.parseDocument(new File(URI.create(uri)));
-            ServerConfigDocument.parseVariablesForBothValues(doc);
+            doc = configDocument.parseDocument(new File(URI.create(uri)));
+            configDocument.parseVariablesForBothValues(doc);
         } catch (XPathExpressionException | IOException e) {
             // TODO Auto-generated catch block
             LOGGER.warning("Error trying to parse document: " + uri);
@@ -36,6 +34,6 @@ public class ServerConfigUtil {
 
     // need method to request Properties from ci.common
     public static Properties getProperties() {
-        return ServerConfigDocument.getProperties();
+        return configDocument.getProperties();
     }
 }

--- a/liberty-ls/src/main/java/io/openliberty/tools/langserver/utils/ServerConfigUtil.java
+++ b/liberty-ls/src/main/java/io/openliberty/tools/langserver/utils/ServerConfigUtil.java
@@ -19,7 +19,6 @@ public class ServerConfigUtil {
     private static CommonLogger log = CommonLogger.getInstance(LOGGER);
     private static ServerConfigDocument configDocument = new ServerConfigDocument(log);
 
-    // need method to request ci.common to parse vars from an xml file
     public static void requestParseXml(String uri) {
         Document doc;
         try {
@@ -32,7 +31,6 @@ public class ServerConfigUtil {
         }
     }
 
-    // need method to request Properties from ci.common
     public static Properties getProperties() {
         return configDocument.getProperties();
     }

--- a/liberty-ls/src/test/java/io/openliberty/tools/langserver/completion/ServerXmlCompletionTest.java
+++ b/liberty-ls/src/test/java/io/openliberty/tools/langserver/completion/ServerXmlCompletionTest.java
@@ -71,15 +71,24 @@ public class ServerXmlCompletionTest extends AbstractCompletionTest {
         completionItems= completions.get().getLeft();
         assertEquals(1, completionItems.size());
         assertEquals("abc", completionItems.get(0).getLabel());
+        assertEquals("abc}", completionItems.get(0).getInsertText());
 
         completions = getCompletion("${ab${http}", new Position(0, 10));
         completionItems= completions.get().getLeft();
         assertEquals(1, completionItems.size());
         assertEquals("http.port", completionItems.get(0).getLabel());
+        assertEquals(null, completionItems.get(0).getInsertText());
 
         completions = getCompletion("${ab${http}", new Position(0, 11));
         completionItems= completions.get().getLeft();
         assertEquals(0, completionItems.size());
+
+        completions = getCompletion("${${ab${http}", new Position(0, 2));
+        completionItems= completions.get().getLeft();
+        assertEquals(2, completionItems.size());
+        for (CompletionItem item : completionItems) {
+            assertTrue(item.getInsertText().contains("}"));;
+        }
     }
 
     protected CompletableFuture<Either<List<CompletionItem>, CompletionList>> getCompletion(String enteredText, Position position) throws URISyntaxException, InterruptedException, ExecutionException, IOException {

--- a/liberty-ls/src/test/java/io/openliberty/tools/langserver/completion/ServerXmlCompletionTest.java
+++ b/liberty-ls/src/test/java/io/openliberty/tools/langserver/completion/ServerXmlCompletionTest.java
@@ -1,0 +1,56 @@
+/*******************************************************************************
+* Copyright (c) 2022 IBM Corporation and others.
+*
+* This program and the accompanying materials are made available under the
+* terms of the Eclipse Public License v. 2.0 which is available at
+* http://www.eclipse.org/legal/epl-2.0.
+*
+* SPDX-License-Identifier: EPL-2.0
+*******************************************************************************/
+package io.openliberty.tools.langserver.completion;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+
+import org.eclipse.lsp4j.CompletionItem;
+import org.eclipse.lsp4j.CompletionList;
+import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.TextDocumentItem;
+import org.eclipse.lsp4j.jsonrpc.messages.Either;
+import org.junit.Test;
+
+import io.openliberty.tools.langserver.LibertyLanguageServer;
+
+public class ServerXmlCompletionTest extends AbstractCompletionTest {
+    // @Test
+    // public void testValueCompletionForBoolean() throws Exception {
+    //     CompletableFuture<Either<List<CompletionItem>, CompletionList>> completions = getCompletion("WLP_LOGGING_APPS_WRITE_JSON=", new Position(0, 38));
+    //     List<CompletionItem> completionItems = completions.get().getLeft();
+    //     assertEquals(2, completionItems.size());
+
+    //     checkCompletionsContainAllStrings(completionItems, ServerPropertyValues.BOOLEAN_VALUES_DEFAULT_TRUE);
+    // }
+
+    @Test
+    public void test1() throws Exception {
+        CompletableFuture<Either<List<CompletionItem>, CompletionList>> completions = getCompletion("${", new Position(1, 4));
+        List<CompletionItem> completionItems = completions.get().getLeft();
+        assertEquals(0, completionItems.size());
+    }
+
+    protected CompletableFuture<Either<List<CompletionItem>, CompletionList>> getCompletion(String enteredText, Position position) throws URISyntaxException, InterruptedException, ExecutionException, IOException {
+        String filename = "server.xml";
+        String resourcesDir = "src/test/resources/xml/";
+        File file = new File(resourcesDir, filename);
+        String fileURI = file.toURI().toString();
+        
+        LibertyLanguageServer lls = initializeLanguageServer(filename, new TextDocumentItem(fileURI, LibertyLanguageServer.LANGUAGE_ID, 0, enteredText));
+        return getCompletionFor(lls, position, fileURI);
+    }
+}

--- a/liberty-ls/src/test/java/io/openliberty/tools/langserver/completion/ServerXmlCompletionTest.java
+++ b/liberty-ls/src/test/java/io/openliberty/tools/langserver/completion/ServerXmlCompletionTest.java
@@ -10,6 +10,7 @@
 package io.openliberty.tools.langserver.completion;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import java.io.File;
 import java.io.IOException;
@@ -28,20 +29,50 @@ import org.junit.Test;
 import io.openliberty.tools.langserver.LibertyLanguageServer;
 
 public class ServerXmlCompletionTest extends AbstractCompletionTest {
-    // @Test
-    // public void testValueCompletionForBoolean() throws Exception {
-    //     CompletableFuture<Either<List<CompletionItem>, CompletionList>> completions = getCompletion("WLP_LOGGING_APPS_WRITE_JSON=", new Position(0, 38));
-    //     List<CompletionItem> completionItems = completions.get().getLeft();
-    //     assertEquals(2, completionItems.size());
-
-    //     checkCompletionsContainAllStrings(completionItems, ServerPropertyValues.BOOLEAN_VALUES_DEFAULT_TRUE);
-    // }
 
     @Test
-    public void test1() throws Exception {
-        CompletableFuture<Either<List<CompletionItem>, CompletionList>> completions = getCompletion("${", new Position(1, 4));
+    public void expansionVariableCompletionRecognitionFalse() throws Exception {
+        CompletableFuture<Either<List<CompletionItem>, CompletionList>> completions = getCompletion("    <include location=\"$", new Position(0, 24));
         List<CompletionItem> completionItems = completions.get().getLeft();
         assertEquals(0, completionItems.size());
+    }
+
+    @Test
+    public void expansionVariableCompletionEarlyPosition() throws Exception {
+        CompletableFuture<Either<List<CompletionItem>, CompletionList>> completions = getCompletion("    <include location=\"${", new Position(0, 0));
+        List<CompletionItem> completionItems = completions.get().getLeft();
+        assertEquals(0, completionItems.size());
+    }
+
+    @Test
+    public void expansionVariableCompletionCorrectPosition() throws Exception {
+        CompletableFuture<Either<List<CompletionItem>, CompletionList>> completions = getCompletion("    <include location=\"${", new Position(0, 25));
+        List<CompletionItem> completionItems = completions.get().getLeft();
+        assertEquals(2, completionItems.size());
+    }
+
+    // This behavior needs to be verified
+    @Test
+    public void expansionVariableCompletionMiddlePosition() throws Exception {
+        CompletableFuture<Either<List<CompletionItem>, CompletionList>> completions = getCompletion("    <include location=\"${abc", new Position(0, 25));
+        List<CompletionItem> completionItems = completions.get().getLeft();
+        assertEquals(2, completionItems.size());
+    }
+
+    @Test
+    public void expansionVariableCompletionFiltration() throws Exception {
+        CompletableFuture<Either<List<CompletionItem>, CompletionList>> completions = getCompletion("    <include location=\"${a", new Position(0, 26));
+        List<CompletionItem> completionItems = completions.get().getLeft();
+        assertEquals(1, completionItems.size());
+        assertEquals("abc", completionItems.get(0).getLabel());
+    }
+
+    @Test
+    public void expansionVariableCompletionFiltration2() throws Exception {
+        CompletableFuture<Either<List<CompletionItem>, CompletionList>> completions = getCompletion("    <include location=\"${http.", new Position(0, 30));
+        List<CompletionItem> completionItems = completions.get().getLeft();
+        assertEquals(1, completionItems.size());
+        assertEquals("http.port", completionItems.get(0).getLabel());
     }
 
     protected CompletableFuture<Either<List<CompletionItem>, CompletionList>> getCompletion(String enteredText, Position position) throws URISyntaxException, InterruptedException, ExecutionException, IOException {

--- a/liberty-ls/src/test/java/io/openliberty/tools/langserver/completion/ServerXmlCompletionTest.java
+++ b/liberty-ls/src/test/java/io/openliberty/tools/langserver/completion/ServerXmlCompletionTest.java
@@ -1,6 +1,7 @@
 package io.openliberty.tools.langserver.completion;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import java.io.File;
@@ -77,7 +78,7 @@ public class ServerXmlCompletionTest extends AbstractCompletionTest {
         completionItems= completions.get().getLeft();
         assertEquals(1, completionItems.size());
         assertEquals("http.port", completionItems.get(0).getLabel());
-        assertEquals(null, completionItems.get(0).getInsertText());
+        assertNull(completionItems.get(0).getInsertText());
 
         completions = getCompletion("${ab${http}", new Position(0, 11));
         completionItems= completions.get().getLeft();
@@ -88,6 +89,13 @@ public class ServerXmlCompletionTest extends AbstractCompletionTest {
         assertEquals(2, completionItems.size());
         for (CompletionItem item : completionItems) {
             assertTrue(item.getInsertText().contains("}"));;
+        }
+
+        completions = getCompletion("${}${ab${http}", new Position(0, 2));
+        completionItems= completions.get().getLeft();
+        assertEquals(2, completionItems.size());
+        for (CompletionItem item : completionItems) {
+            assertNull(item.getInsertText());
         }
     }
 

--- a/liberty-ls/src/test/java/io/openliberty/tools/langserver/hover/ServerXmlHoverTest.java
+++ b/liberty-ls/src/test/java/io/openliberty/tools/langserver/hover/ServerXmlHoverTest.java
@@ -26,16 +26,30 @@ public class ServerXmlHoverTest extends AbstractHoverTest {
 
     @Test
     public void testHoverEmpty() throws Exception {
-        String propertyEntry = "    <include location=\"${abc}\"/>";
-        CompletableFuture<Hover> hover = getHover(propertyEntry, 0);
+        String intputLine = "    <include location=\"${abc}\"/>";
+        CompletableFuture<Hover> hover = getHover(intputLine, 0);
         assertEquals("", hover.get().getContents().getRight().getValue());
     }
 
     @Test
     public void testHoverValue() throws Exception {
-        String propertyEntry = "    <include location=\"${abc}\"/>";
-        CompletableFuture<Hover> hover = getHover(propertyEntry, 27);
+        String inputLine = "    <include location=\"${abc}\"/>";
+        CompletableFuture<Hover> hover = getHover(inputLine, 27);
         assertEquals("def", hover.get().getContents().getRight().getValue());
+    }
+
+    @Test
+    public void testHoverEmpty2() throws Exception {
+        String inputLine = "    <httpEndpoint httpPort=\"${http.port}\" httpsPort=\"9443\" id=\"defaultHttpEndpoint\"/>";
+        CompletableFuture<Hover> hover = getHover(inputLine, 42);
+        assertEquals("", hover.get().getContents().getRight().getValue());
+    }
+
+    @Test
+    public void testHoverValue2() throws Exception {
+        String inputLine = "    <httpEndpoint httpPort=\"${http.port}\" httpsPort=\"9443\" id=\"defaultHttpEndpoint\"/>";
+        CompletableFuture<Hover> hover = getHover(inputLine, 33);
+        assertEquals("9080", hover.get().getContents().getRight().getValue());
     }
 
     private CompletableFuture<Hover> getHover(String propertyEntry, int position) throws URISyntaxException, InterruptedException, ExecutionException {

--- a/liberty-ls/src/test/java/io/openliberty/tools/langserver/hover/ServerXmlHoverTest.java
+++ b/liberty-ls/src/test/java/io/openliberty/tools/langserver/hover/ServerXmlHoverTest.java
@@ -1,0 +1,50 @@
+/*******************************************************************************
+* Copyright (c) 2022 IBM Corporation and others.
+*
+* This program and the accompanying materials are made available under the
+* terms of the Eclipse Public License v. 2.0 which is available at
+* http://www.eclipse.org/legal/epl-2.0.
+*
+* SPDX-License-Identifier: EPL-2.0
+*******************************************************************************/
+package io.openliberty.tools.langserver.hover;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.File;
+import java.net.URISyntaxException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+
+import org.eclipse.lsp4j.Hover;
+import org.eclipse.lsp4j.TextDocumentItem;
+import org.junit.Test;
+
+import io.openliberty.tools.langserver.LibertyLanguageServer;
+
+public class ServerXmlHoverTest extends AbstractHoverTest {
+
+    @Test
+    public void testHoverEmpty() throws Exception {
+        String propertyEntry = "    <include location=\"${abc}\"/>";
+        CompletableFuture<Hover> hover = getHover(propertyEntry, 0);
+        assertEquals("", hover.get().getContents().getRight().getValue());
+    }
+
+    @Test
+    public void testHoverValue() throws Exception {
+        String propertyEntry = "    <include location=\"${abc}\"/>";
+        CompletableFuture<Hover> hover = getHover(propertyEntry, 27);
+        assertEquals("def", hover.get().getContents().getRight().getValue());
+    }
+
+    private CompletableFuture<Hover> getHover(String propertyEntry, int position) throws URISyntaxException, InterruptedException, ExecutionException {
+        String filename = "server.xml";
+        String resourcesDir = "src/test/resources/xml/";
+        File file = new File(resourcesDir, filename);
+        String fileURI = file.toURI().toString();
+
+        LibertyLanguageServer lls = initializeLanguageServer(filename, new TextDocumentItem(fileURI, LibertyLanguageServer.LANGUAGE_ID, 0, propertyEntry));
+        return getHover(lls, position, fileURI);
+    }
+}

--- a/liberty-ls/src/test/java/io/openliberty/tools/langserver/hover/ServerXmlHoverTest.java
+++ b/liberty-ls/src/test/java/io/openliberty/tools/langserver/hover/ServerXmlHoverTest.java
@@ -1,12 +1,3 @@
-/*******************************************************************************
-* Copyright (c) 2022 IBM Corporation and others.
-*
-* This program and the accompanying materials are made available under the
-* terms of the Eclipse Public License v. 2.0 which is available at
-* http://www.eclipse.org/legal/epl-2.0.
-*
-* SPDX-License-Identifier: EPL-2.0
-*******************************************************************************/
 package io.openliberty.tools.langserver.hover;
 
 import static org.junit.Assert.assertEquals;
@@ -23,32 +14,24 @@ import org.junit.Test;
 import io.openliberty.tools.langserver.LibertyLanguageServer;
 
 public class ServerXmlHoverTest extends AbstractHoverTest {
+    static String entryLine;
+    static CompletableFuture<Hover> hover;
 
     @Test
-    public void testHoverEmpty() throws Exception {
-        String intputLine = "    <include location=\"${abc}\"/>";
-        CompletableFuture<Hover> hover = getHover(intputLine, 0);
+    public void testHover() throws Exception {
+        // Hover over blank space
+        entryLine = "    <httpEndpoint httpPort=\"${http.port}\" httpsPort=\"${not.defined}\" id=\"defaultHttpEndpoint\"/>";
+        hover = getHover(entryLine, 0);
         assertEquals("", hover.get().getContents().getRight().getValue());
-    }
 
-    @Test
-    public void testHoverValue() throws Exception {
-        String inputLine = "    <include location=\"${abc}\"/>";
-        CompletableFuture<Hover> hover = getHover(inputLine, 27);
-        assertEquals("def", hover.get().getContents().getRight().getValue());
-    }
-
-    @Test
-    public void testHoverEmpty2() throws Exception {
-        String inputLine = "    <httpEndpoint httpPort=\"${http.port}\" httpsPort=\"9443\" id=\"defaultHttpEndpoint\"/>";
-        CompletableFuture<Hover> hover = getHover(inputLine, 42);
+        // Hover over undefined variable
+        entryLine = "    <httpEndpoint httpPort=\"${http.port}\" httpsPort=\"${not.defined}\" id=\"defaultHttpEndpoint\"/>";
+        hover = getHover(entryLine, 65);
         assertEquals("", hover.get().getContents().getRight().getValue());
-    }
 
-    @Test
-    public void testHoverValue2() throws Exception {
-        String inputLine = "    <httpEndpoint httpPort=\"${http.port}\" httpsPort=\"9443\" id=\"defaultHttpEndpoint\"/>";
-        CompletableFuture<Hover> hover = getHover(inputLine, 33);
+        // Hover over defined variable
+        entryLine = "    <httpEndpoint httpPort=\"${http.port}\" httpsPort=\"9443\" id=\"defaultHttpEndpoint\"/>";
+        hover = getHover(entryLine, 33);
         assertEquals("9080", hover.get().getContents().getRight().getValue());
     }
 

--- a/liberty-ls/src/test/resources/xml/server.xml
+++ b/liberty-ls/src/test/resources/xml/server.xml
@@ -1,4 +1,6 @@
 <server>
     <variable name="abc" value="def"/>
+    <variable name="http.port" value="9080"/>
     <include location="${abc}"/>
+    <httpEndpoint httpPort="${http.port}" httpsPort="9443" id="defaultHttpEndpoint"/>
 </server>

--- a/liberty-ls/src/test/resources/xml/server.xml
+++ b/liberty-ls/src/test/resources/xml/server.xml
@@ -1,0 +1,4 @@
+<server>
+    <variable name="abc" value="def"/>
+    <include location="${abc}"/>
+</server>


### PR DESCRIPTION
Addressing issue #68 

- Add ci.common as dependency
- ExpansionVariableInstance class
  - Contains logic for hover and completion recognition
  - Currently limited to variables and values within the same server.xml (until further file support is added)
  
 Completion: 
<img width="359" alt="image" src="https://github.com/OpenLiberty/liberty-language-server/assets/8934136/953a3b7b-d3a4-4b0d-bbe6-8e5f1ecb2e2e">
<img width="325" alt="image" src="https://github.com/OpenLiberty/liberty-language-server/assets/8934136/1d6b3b03-7ffe-4c0b-8a40-8ea40a312fd3">

Hover:
<img width="321" alt="image" src="https://github.com/OpenLiberty/liberty-language-server/assets/8934136/1a87a610-8e24-4266-97f0-86d3c60b4c50">
