### PR TITLE
Feature completion fix

### DIFF
--- a/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/LibertyCodeActionParticipant.java
+++ b/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/LibertyCodeActionParticipant.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2022, 2023 IBM Corporation and others.
+* Copyright (c) 2022, 2024 IBM Corporation and others.
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License v. 2.0 which is available at

--- a/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/LibertyCompletionParticipant.java
+++ b/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/LibertyCompletionParticipant.java
@@ -165,7 +165,7 @@ public class LibertyCompletionParticipant extends CompletionParticipantAdapter {
             String featureNameLowerCase = featureName.toLowerCase();
 
             // strip off version number after the - so that we can provide all possible valid versions of a feature for completion
-            String featureNameToCompare = LibertyUtils.stripVersion(featureNameLowerCase);
+            String featureNameToCompare = featureNameLowerCase.contains("-") ? featureNameLowerCase.substring(0, featureNameLowerCase.lastIndexOf("-")+1) : featureNameLowerCase;
 
             List<Feature> completionFeatures = FeatureService.getInstance().getFeatureReplacements(featureNameToCompare, featureMgrNode, libertyVersion, libertyRuntime, requestDelay, domDocument.getDocumentURI());
             return getFeatureCompletionItems(featureElement, domDocument, completionFeatures);

--- a/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/services/FeatureService.java
+++ b/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/services/FeatureService.java
@@ -299,7 +299,7 @@ public class FeatureService {
      */
     public List<String> collectExistingFeatures(DOMNode featureManager, String currentFeatureName) {
         List<String> includedFeatures = new ArrayList<>();
-
+        boolean alreadyIgnoredOnce = false;
         if (featureManager == null) {
             return includedFeatures;
         }
@@ -311,7 +311,10 @@ public class FeatureService {
             if (featureNode.getNodeName().equals(LibertyConstants.FEATURE_ELEMENT) && featureTextNode != null) {
                 String featureName = featureTextNode.getTextContent();
                 String featureNameLowerCase = featureName.toLowerCase();
-                if (currentFeatureName == null || (currentFeatureName != null && !featureNameLowerCase.equalsIgnoreCase(currentFeatureName))) {
+                // if same feature is repeated, ignore it first time, but add for second time onwards
+                if (featureNameLowerCase.equalsIgnoreCase(currentFeatureName) && !alreadyIgnoredOnce) {
+                    alreadyIgnoredOnce = true;
+                } else {
                     includedFeatures.add(featureNameLowerCase);
                 }
             }

--- a/lemminx-liberty/src/test/java/io/openliberty/LibertyCompletionTest.java
+++ b/lemminx-liberty/src/test/java/io/openliberty/LibertyCompletionTest.java
@@ -206,6 +206,22 @@ public class LibertyCompletionTest {
                 // one for CDATA and one for <-
                 sipServletCompletionItem = c("sipServlet-1.1", "sipServlet-1.1");
                 XMLAssert.testCompletionFor(serverXML, null, serverXMLURI, 3, sipServletCompletionItem);
+
+                serverXML = String.join(newLine, //
+                        "<server description=\"Sample Liberty server\">", //
+                        "       <featureManager>", //
+                        "               <feature>servlet-</feature>", //
+                        "               <feature>servlet</feature>", //
+                        "               <feature>servlet|</feature>", //
+                        "       </featureManager>", //
+                        "</server>" //
+                );
+
+                // total number of available completion items
+                // 1 for sipServlet-1.1
+                // one for CDATA and one for <-
+                sipServletCompletionItem = c("sipServlet-1.1", "sipServlet-1.1");
+                XMLAssert.testCompletionFor(serverXML, null, serverXMLURI, 3, sipServletCompletionItem);
         }
 
 }

--- a/lemminx-liberty/src/test/java/io/openliberty/LibertyCompletionTest.java
+++ b/lemminx-liberty/src/test/java/io/openliberty/LibertyCompletionTest.java
@@ -159,4 +159,53 @@ public class LibertyCompletionTest {
                 XMLAssert.testCompletionFor(serverXML, null, serverXMLURI, 8);
         }
 
+        // Tests the feature completion for same feature repetition
+        @Test
+        public void testFeatureRepetitionCompletionItem() throws BadLocationException {
+                String serverXML = String.join(newLine, //
+                        "<server description=\"Sample Liberty server\">", //
+                        "       <featureManager>", //
+                        "               <feature>servlet</feature>", //
+                        "               <feature>servlet|</feature>", //
+                        "       </featureManager>", //
+                        "</server>" //
+                );
+
+                // total number of available completion items
+                // 1 for sipServlet-1.1
+                // one for CDATA and one for <-
+                CompletionItem sipServletCompletionItem = c("sipServlet-1.1", "sipServlet-1.1");
+                XMLAssert.testCompletionFor(serverXML, null, serverXMLURI, 3, sipServletCompletionItem);
+
+                serverXML = String.join(newLine, //
+                        "<server description=\"Sample Liberty server\">", //
+                        "       <featureManager>", //
+                        "               <feature>servlet-|</feature>", //
+                        "               <feature>servlet</feature>", //
+                        "       </featureManager>", //
+                        "</server>" //
+                );
+
+                // total number of available completion items
+                // 1 for sipServlet-1.1
+                // one for CDATA and one for <-
+                sipServletCompletionItem = c("sipServlet-1.1", "sipServlet-1.1");
+                XMLAssert.testCompletionFor(serverXML, null, serverXMLURI, 3, sipServletCompletionItem);
+
+                serverXML = String.join(newLine, //
+                        "<server description=\"Sample Liberty server\">", //
+                        "       <featureManager>", //
+                        "               <feature>servlet-3.1</feature>", //
+                        "               <feature>servlet|</feature>", //
+                        "       </featureManager>", //
+                        "</server>" //
+                );
+
+                // total number of available completion items
+                // 1 for sipServlet-1.1
+                // one for CDATA and one for <-
+                sipServletCompletionItem = c("sipServlet-1.1", "sipServlet-1.1");
+                XMLAssert.testCompletionFor(serverXML, null, serverXMLURI, 3, sipServletCompletionItem);
+        }
+
 }


### PR DESCRIPTION
Fix for https://github.com/OpenLiberty/liberty-tools-intellij/issues/1035

Issue identified due to 2 things
1. when same featurename is added multiple times, its not getting added to existing features since code consider both are current line feature
2. In code LibertyCompletionParticpant#buildCompletionItems(), previous code was not striping full version field, it was keeping "-" . when we changed to LibertyUtils.stripVersion, hyphen got removed. resolving that issue