### PR TITLE
UnsupportedOperationException fix in LCLS

### DIFF
--- a/liberty-ls/src/main/java/io/openliberty/tools/langserver/LibertyLanguageServer.java
+++ b/liberty-ls/src/main/java/io/openliberty/tools/langserver/LibertyLanguageServer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2020, 2023 IBM Corporation and others.
+* Copyright (c) 2020, 2024 IBM Corporation and others.
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License v. 2.0 which is available at

--- a/liberty-ls/src/main/java/io/openliberty/tools/langserver/LibertyLanguageServer.java
+++ b/liberty-ls/src/main/java/io/openliberty/tools/langserver/LibertyLanguageServer.java
@@ -127,8 +127,7 @@ public class LibertyLanguageServer extends AbstractLanguageServer implements Pro
 
     @Override
     public void setTrace(SetTraceParams params) {
-        LOGGER.warning("setTrace Reached");
-        // to avoid having UnsupportedOperationException, the method is implemented
+        // to avoid exception in vscode, the method is implemented
         // FIXME : implement the behavior of this method.
     }
 }

--- a/liberty-ls/src/main/java/io/openliberty/tools/langserver/LibertyLanguageServer.java
+++ b/liberty-ls/src/main/java/io/openliberty/tools/langserver/LibertyLanguageServer.java
@@ -21,6 +21,7 @@ import org.eclipse.lsp4j.InitializeParams;
 import org.eclipse.lsp4j.InitializeResult;
 import org.eclipse.lsp4j.InitializedParams;
 import org.eclipse.lsp4j.ServerCapabilities;
+import org.eclipse.lsp4j.SetTraceParams;
 import org.eclipse.lsp4j.TextDocumentSyncKind;
 import org.eclipse.lsp4j.services.LanguageClient;
 import org.eclipse.lsp4j.services.LanguageClientAware;
@@ -122,5 +123,12 @@ public class LibertyLanguageServer extends AbstractLanguageServer implements Pro
 
     public void setLanguageClient(LanguageClient languageClient) {
         this.languageClient = languageClient;
+    }
+
+    @Override
+    public void setTrace(SetTraceParams params) {
+        LOGGER.warning("setTrace Reached");
+        // to avoid having UnsupportedOperationException, the method is implemented
+        // FIXME : implement the behavior of this method.
     }
 }

--- a/liberty-ls/src/main/java/io/openliberty/tools/langserver/LibertyLanguageServer.java
+++ b/liberty-ls/src/main/java/io/openliberty/tools/langserver/LibertyLanguageServer.java
@@ -127,7 +127,7 @@ public class LibertyLanguageServer extends AbstractLanguageServer implements Pro
 
     @Override
     public void setTrace(SetTraceParams params) {
-        // to avoid exception in vscode, the method is implemented
+        // to avoid having UnsupportedOperationException, the method is implemented
         // FIXME : implement the behavior of this method.
     }
 }


### PR DESCRIPTION
Fixes #320 
Implemented the method setTrace() in the interface LanguageServer in the class LibertyLanguageServer.