### PR TITLE
Use private features to collect available platforms

### DIFF
--- a/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/LibertyCompletionParticipant.java
+++ b/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/LibertyCompletionParticipant.java
@@ -219,7 +219,7 @@ public class LibertyCompletionParticipant extends CompletionParticipantAdapter {
             List<Feature> completionFeatures = FeatureService.getInstance().getFeatureReplacements(featureNameToCompare, featureMgrNode, libertyVersion, libertyRuntime, requestDelay, domDocument.getDocumentURI());
             return getFeatureCompletionItems(featureElement, domDocument, completionFeatures);
         } else {
-            List<Feature> features = FeatureService.getInstance().getFeatures(libertyVersion, libertyRuntime, requestDelay, domDocument.getDocumentURI());
+            List<Feature> features = FeatureService.getInstance().getFeaturesAndPlatforms(libertyVersion, libertyRuntime, requestDelay, domDocument.getDocumentURI()).getPublicFeatures();
             return getUniqueFeatureCompletionItems(featureElement, domDocument, features, existingFeatures);
         }
     }

--- a/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/LibertyDiagnosticParticipant.java
+++ b/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/LibertyDiagnosticParticipant.java
@@ -117,11 +117,7 @@ public class LibertyDiagnosticParticipant implements IDiagnosticsParticipant {
         String docContent = domDocument.getTextDocument().getText();
         List<VariableLoc> variables = LibertyUtils.getVariablesFromTextContent(docContent);
         Properties variablesMap = SettingsService.getInstance().getVariablesForServerXml(domDocument.getDocumentURI());
-        if ((variablesMap == null) || (variablesMap.isEmpty() && !variables.isEmpty())) {
-            if (variablesMap == null) {
-                LOGGER.warning("CLK999: variablesMap is NULL!");
-                return;
-            }
+        if (variablesMap.isEmpty() && !variables.isEmpty()) {
             String message = "WARNING: Variable resolution is not available for workspace %s. Please start the Liberty server for the workspace to enable variable resolution.";
             LibertyWorkspace workspace = LibertyProjectsManager.getInstance().getWorkspaceFolder(domDocument.getDocumentURI());
             Range range = XMLPositionUtility.createRange(domDocument.getDocumentElement().getStartTagOpenOffset(), domDocument.getDocumentElement().getStartTagCloseOffset(),

--- a/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/LibertyDiagnosticParticipant.java
+++ b/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/LibertyDiagnosticParticipant.java
@@ -117,7 +117,11 @@ public class LibertyDiagnosticParticipant implements IDiagnosticsParticipant {
         String docContent = domDocument.getTextDocument().getText();
         List<VariableLoc> variables = LibertyUtils.getVariablesFromTextContent(docContent);
         Properties variablesMap = SettingsService.getInstance().getVariablesForServerXml(domDocument.getDocumentURI());
-        if (variablesMap.isEmpty() && !variables.isEmpty()) {
+        if ((variablesMap == null) || (variablesMap.isEmpty() && !variables.isEmpty())) {
+            if (variablesMap == null) {
+                LOGGER.warning("CLK999: variablesMap is NULL!");
+                return;
+            }
             String message = "WARNING: Variable resolution is not available for workspace %s. Please start the Liberty server for the workspace to enable variable resolution.";
             LibertyWorkspace workspace = LibertyProjectsManager.getInstance().getWorkspaceFolder(domDocument.getDocumentURI());
             Range range = XMLPositionUtility.createRange(domDocument.getDocumentElement().getStartTagOpenOffset(), domDocument.getDocumentElement().getStartTagCloseOffset(),

--- a/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/models/feature/FeatureInfo.java
+++ b/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/models/feature/FeatureInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2020, 2023 IBM Corporation and others.
+* Copyright (c) 2020, 2025 IBM Corporation and others.
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License v. 2.0 which is available at
@@ -26,11 +26,22 @@ public class FeatureInfo {
     @XmlElement(name = "feature")
     private List<Feature> features = null;
 
+    @XmlElement(name = "privateFeature")
+    private List<PrivateFeature> privateFeatures = null;
+
     public List<Feature> getFeatures() {
         return features;
     }
 
     public void setFeatures(List<Feature> features) {
         this.features = features;
+    }
+
+    public List<PrivateFeature> getPrivateFeatures() {
+        return this.privateFeatures;
+    }
+
+    public void setPrivateFeatures(List<PrivateFeature> privateFeatures) {
+        this.privateFeatures = privateFeatures;
     }
 }

--- a/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/models/feature/FeaturesAndPlatforms.java
+++ b/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/models/feature/FeaturesAndPlatforms.java
@@ -30,7 +30,7 @@ public class FeaturesAndPlatforms {
         this.publicFeatures = publicFeatures;
         this.privateFeatures = privateFeatures;
 
-        platforms = privateFeatures.stream()
+        this.platforms = privateFeatures.stream()
                 .filter(f -> f.getWlpInformation().getVisibility() != null && f.getWlpInformation().getVisibility().equals(LibertyConstants.PRIVATE_VISIBILITY))
                 .map(Feature::getWlpInformation)
                 .filter(Objects::nonNull)

--- a/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/models/feature/FeaturesAndPlatforms.java
+++ b/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/models/feature/FeaturesAndPlatforms.java
@@ -31,9 +31,10 @@ public class FeaturesAndPlatforms {
         this.privateFeatures = privateFeatures;
 
         this.platforms = privateFeatures.stream()
-                .filter(f -> f.getWlpInformation().getVisibility() != null && f.getWlpInformation().getVisibility().equals(LibertyConstants.PRIVATE_VISIBILITY))
                 .map(Feature::getWlpInformation)
                 .filter(Objects::nonNull)
+                .filter(w -> Objects.nonNull(w.getVisibility()))
+                .filter(w -> w.getVisibility().equals(LibertyConstants.PRIVATE_VISIBILITY))
                 .map(WlpInformation::getPlatforms)
                 .filter(Objects::nonNull)
                 .flatMap(List::stream).collect(Collectors.toSet());

--- a/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/models/feature/FeaturesAndPlatforms.java
+++ b/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/models/feature/FeaturesAndPlatforms.java
@@ -1,0 +1,65 @@
+/*******************************************************************************
+* Copyright (c) 2025 IBM Corporation and others.
+*
+* This program and the accompanying materials are made available under the
+* terms of the Eclipse Public License v. 2.0 which is available at
+* http://www.eclipse.org/legal/epl-2.0.
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*     IBM Corporation - initial API and implementation
+*******************************************************************************/
+package io.openliberty.tools.langserver.lemminx.models.feature;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import io.openliberty.tools.langserver.lemminx.util.LibertyConstants;
+
+public class FeaturesAndPlatforms {
+    private List<Feature> publicFeatures;
+    private List<Feature> privateFeatures;
+    private Set<String> platforms;
+    
+    public FeaturesAndPlatforms(List<Feature> publicFeatures, List<Feature> privateFeatures) {
+        this.publicFeatures = publicFeatures;
+        this.privateFeatures = privateFeatures;
+
+        platforms = privateFeatures.stream()
+                .filter(f -> f.getWlpInformation().getVisibility() != null && f.getWlpInformation().getVisibility().equals(LibertyConstants.PRIVATE_VISIBILITY))
+                .map(Feature::getWlpInformation)
+                .filter(Objects::nonNull)
+                .map(WlpInformation::getPlatforms)
+                .filter(Objects::nonNull)
+                .flatMap(List::stream).collect(Collectors.toSet());
+    }
+
+    public FeaturesAndPlatforms() {
+        this.publicFeatures = new ArrayList<>();
+        this.privateFeatures = new ArrayList<>();
+        this.platforms = new HashSet<>();
+    }
+
+    public void addFeaturesAndPlatforms(FeaturesAndPlatforms fp) {
+        this.publicFeatures.addAll(fp.getPublicFeatures());
+        this.privateFeatures.addAll(fp.getPrivateFeatures());
+        this.platforms.addAll(fp.getPlatforms());
+    }
+
+    public List<Feature> getPublicFeatures() {
+        return this.publicFeatures;
+    }
+
+    public List<Feature> getPrivateFeatures() {
+        return this.privateFeatures;
+    }
+
+    public Set<String> getPlatforms() {
+        return this.platforms;
+    }
+}

--- a/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/models/feature/PrivateFeature.java
+++ b/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/models/feature/PrivateFeature.java
@@ -1,0 +1,56 @@
+/*******************************************************************************
+* Copyright (c) 2025 IBM Corporation and others.
+*
+* This program and the accompanying materials are made available under the
+* terms of the Eclipse Public License v. 2.0 which is available at
+* http://www.eclipse.org/legal/epl-2.0.
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*     IBM Corporation - initial API and implementation
+*******************************************************************************/
+package io.openliberty.tools.langserver.lemminx.models.feature;
+
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import java.util.List;
+
+@XmlRootElement(name = "privateFeature")
+@XmlAccessorType(XmlAccessType.FIELD)
+public class PrivateFeature {
+
+    private String symbolicName;
+    private List<String> platform;
+
+    WlpInformation wlpInformation;
+
+    // Getter Methods
+
+    public String getSymbolicName() {
+        return symbolicName;
+    }
+
+    public WlpInformation getWlpInformation() {
+        return wlpInformation;
+    }
+
+    public List<String> getPlatforms() {
+        return platform;
+    }
+
+    // Setter Methods
+
+    public void setSymbolicName(String symbolicName) {
+        this.symbolicName = symbolicName;
+    }
+
+    public void setWlpInformation(WlpInformation wlpInformation) {
+        this.wlpInformation = wlpInformation;
+    }
+
+    public void setPlatforms(List<String> platforms) {
+        this.platform = platforms;
+    }
+}

--- a/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/models/feature/PrivateFeature.java
+++ b/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/models/feature/PrivateFeature.java
@@ -24,16 +24,10 @@ public class PrivateFeature {
     private String symbolicName;
     private List<String> platform;
 
-    WlpInformation wlpInformation;
-
     // Getter Methods
 
     public String getSymbolicName() {
         return symbolicName;
-    }
-
-    public WlpInformation getWlpInformation() {
-        return wlpInformation;
     }
 
     public List<String> getPlatforms() {
@@ -44,10 +38,6 @@ public class PrivateFeature {
 
     public void setSymbolicName(String symbolicName) {
         this.symbolicName = symbolicName;
-    }
-
-    public void setWlpInformation(WlpInformation wlpInformation) {
-        this.wlpInformation = wlpInformation;
     }
 
     public void setPlatforms(List<String> platforms) {

--- a/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/services/FeatureService.java
+++ b/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/services/FeatureService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2020, 2024 IBM Corporation and others.
+* Copyright (c) 2020, 2025 IBM Corporation and others.
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License v. 2.0 which is available at

--- a/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/services/FeatureService.java
+++ b/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/services/FeatureService.java
@@ -549,6 +549,7 @@ public class FeatureService {
                     WlpInformation wlpInfo = new WlpInformation(f.getName());
                     f.setWlpInformation(wlpInfo);
                     wlpInfo.setVisibility(LibertyConstants.PRIVATE_VISIBILITY);
+                    wlpInfo.setPlatforms(pf.getPlatforms());
 
                     privateFeatures.add(f);
                 }

--- a/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/services/FeatureService.java
+++ b/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/services/FeatureService.java
@@ -21,18 +21,19 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.logging.Logger;
 
 import io.openliberty.tools.langserver.lemminx.models.feature.FeatureTolerate;
+import io.openliberty.tools.langserver.lemminx.models.feature.FeaturesAndPlatforms;
+import io.openliberty.tools.langserver.lemminx.models.feature.PrivateFeature;
+
 import org.eclipse.lemminx.dom.DOMDocument;
 import org.eclipse.lemminx.dom.DOMNode;
 import org.eclipse.lemminx.uriresolver.CacheResourcesManager;
@@ -95,13 +96,13 @@ public class FeatureService {
     }
 
     // Cache of Liberty version -> list of supported features
-    private Map<String, List<Feature>> featureCache;   // the key consists of runtime-version, where runtime is 'ol' or 'wlp'
-    private List<Feature> defaultFeatures;
+    private Map<String, FeaturesAndPlatforms> featureAndPlatformCache;   // the key consists of runtime-version, where runtime is 'ol' or 'wlp'
+    private FeaturesAndPlatforms defaultFeaturesAndPlatforms;
     private FeatureListGraph defaultFeatureList;
     private long featureUpdateTime;
 
     private FeatureService() {
-        featureCache = new HashMap<>();
+        featureAndPlatformCache = new HashMap<>();
         featureUpdateTime = -1;
     }
 
@@ -111,66 +112,76 @@ public class FeatureService {
      * @param libertyVersion - version of Liberty to fetch features for
      * @return list of features supported by the provided version of Liberty
      */
-    private List<Feature> fetchFeaturesForVersion(String libertyVersion, String libertyRuntime) throws IOException, JsonParseException {
+    private FeaturesAndPlatforms fetchFeaturesForVersion(String libertyVersion, String libertyRuntime) throws IOException, JsonParseException {
         String featureEndpoint = libertyRuntime.equals("wlp") ? String.format(wlpFeatureEndpoint, libertyVersion) : 
                                                                 String.format(olFeatureEndpoint, libertyVersion);
 
         InputStreamReader reader = new InputStreamReader(new URL(featureEndpoint).openStream());
 
         // Only need the public features
-        List<Feature> publicFeatures = readPublicFeatures(reader);
+        FeaturesAndPlatforms fp = readFeaturesAndPlatforms(reader);
 
         if (libertyRuntime.equals("wlp")) {
             // need to also get the OpenLiberty features and add them to the list to return
-            List<Feature> olFeatures = fetchFeaturesForVersion(libertyVersion, "ol");
-            publicFeatures.addAll(olFeatures);
+            FeaturesAndPlatforms olFP = fetchFeaturesForVersion(libertyVersion, "ol");
+            fp.addFeaturesAndPlatforms(olFP);
         }
 
-        LOGGER.info("Returning public features from Maven: " + publicFeatures.size());
-        return publicFeatures;
+        LOGGER.info("Returning public features and platforms from Maven - features: " + fp.getPublicFeatures().size()+" platforms: "+fp.getPlatforms().size());
+        return fp;
     }
 
     /**
-     * Returns the default list of features
+     * Returns the default list of features and platforms
      *
-     * @return list of features supported by the default version of Liberty
+     * @return list of features and platforms supported by the default version of Liberty
      */
-    private List<Feature> getDefaultFeatures() {
+    private FeaturesAndPlatforms getDefaultFeaturesAndPlatforms() {
         try {
-            if (defaultFeatures == null) {
+            if (defaultFeaturesAndPlatforms == null) {
                 // Changing this to contain the version in the file name since the file is copied to the local .lemminx cache. 
                 // This is how we ensure the latest default features json gets used in each developer environment. 
                 InputStream is = getClass().getClassLoader().getResourceAsStream("features-cached-24.0.0.12.json");
                 InputStreamReader reader = new InputStreamReader(is, StandardCharsets.UTF_8);
 
                 // Only need the public features
-                defaultFeatures = readPublicFeatures(reader);
+                defaultFeaturesAndPlatforms = readFeaturesAndPlatforms(reader);
             }
-            LOGGER.info("Returning default list of features");
-            return defaultFeatures;
+            LOGGER.info("Returning default list of features and platforms");
+            return defaultFeaturesAndPlatforms;
 
         } catch (JsonParseException e) {
             // unable to read json in resources file, return empty list
-            LOGGER.severe("Error: Unable to get default features.");
-            return defaultFeatures;
+            LOGGER.severe("Error: Unable to get default features and platforms.");
+            defaultFeaturesAndPlatforms = new FeaturesAndPlatforms();
+            return defaultFeaturesAndPlatforms;
         }
     }
 
     /**
-     * Returns a list of public features found in the passed input stream. Does not affect the default feature list.
+     * Returns an object with a list of public features found in the passed input stream. Does not affect the default feature list.
+     * The returned object also contains a list of private features, and a set of available platforms.
      *
      * @param reader - InputStreamReader for json feature list
-     * @return list of public features
+     * @return FeaturesAndPlatforms with a list of public features, list of private features, and set of available platforms.
      */
-    private ArrayList<Feature> readPublicFeatures(InputStreamReader reader) throws JsonParseException {
+    private FeaturesAndPlatforms readFeaturesAndPlatforms(InputStreamReader reader) throws JsonParseException {
         Feature[] featureList = new Gson().fromJson(reader, Feature[].class);
 
         ArrayList<Feature> publicFeatures = new ArrayList<>();
+        ArrayList<Feature> privateFeatures = new ArrayList<>();
+
         // Guard against null visibility field. Ran into this during manual testing of a wlp installation.
-        Arrays.asList(featureList).stream()
-            .filter(f -> f.getWlpInformation().getVisibility() != null && f.getWlpInformation().getVisibility().equals(LibertyConstants.PUBLIC_VISIBILITY))
-            .forEach(publicFeatures::add);
-        return publicFeatures;
+        for (int i=0; i < featureList.length; i++) {
+            if (featureList[i].getWlpInformation().getVisibility() != null) {
+                if (featureList[i].getWlpInformation().getVisibility().equals(LibertyConstants.PUBLIC_VISIBILITY)) {
+                    publicFeatures.add(featureList[i]);
+                } else if (featureList[i].getWlpInformation().getVisibility().equals(LibertyConstants.PRIVATE_VISIBILITY)) {
+                    privateFeatures.add(featureList[i]);
+                }
+            }
+        }
+        return new FeaturesAndPlatforms(publicFeatures, privateFeatures);
     }
 
     /**
@@ -185,10 +196,10 @@ public class FeatureService {
      * @param documentURI Liberty XML document
      * @return List of possible features
      */
-    public List<Feature> getFeatures(String libertyVersion, String libertyRuntime, int requestDelay, String documentURI) {
+    public FeaturesAndPlatforms getFeaturesAndPlatforms(String libertyVersion, String libertyRuntime, int requestDelay, String documentURI) {
         if (libertyRuntime == null || libertyVersion == null) {
             // return default list of features
-            List<Feature> defaultFeatures = getDefaultFeatures(); 
+            FeaturesAndPlatforms defaultFeatures = getDefaultFeaturesAndPlatforms(); 
             getDefaultFeatureList();
             return defaultFeatures;
         }
@@ -196,12 +207,12 @@ public class FeatureService {
         String featureCacheKey = libertyRuntime + "-" + libertyVersion;
 
         // if the features are already cached in the feature cache
-        if (featureCache.containsKey(featureCacheKey)) {
-            LOGGER.info("Getting cached features for: " + featureCacheKey);
-            return featureCache.get(featureCacheKey);
+        if (featureAndPlatformCache.containsKey(featureCacheKey)) {
+            LOGGER.info("Getting cached features and platforms for: " + featureCacheKey);
+            return featureAndPlatformCache.get(featureCacheKey);
         }
 
-        LOGGER.info("Getting features for: " + featureCacheKey);
+        LOGGER.info("Getting features and platforms for: " + featureCacheKey);
 
         // if not a beta runtime, fetch features from maven central
         // - beta runtimes do not have a published features.json in mc
@@ -212,8 +223,8 @@ public class FeatureService {
                 // switching back and forth between projects.
                 long currentTime = System.currentTimeMillis();
                 if (this.featureUpdateTime == -1 || currentTime >= (this.featureUpdateTime + (requestDelay * 1000))) {
-                    List<Feature> features = fetchFeaturesForVersion(libertyVersion, libertyRuntime);
-                    featureCache.put(featureCacheKey, features);
+                    FeaturesAndPlatforms features = fetchFeaturesForVersion(libertyVersion, libertyRuntime);
+                    featureAndPlatformCache.put(featureCacheKey, features);
                     this.featureUpdateTime = System.currentTimeMillis();
                     return features;
                 }
@@ -225,18 +236,20 @@ public class FeatureService {
 
         // fetch installed features list - this would only happen if a features.json was not able to be downloaded from Maven Central
         // This is the case for beta runtimes and for very old runtimes pre 18.0.0.2 (or if within the requestDelay window of 120 seconds).
-        List<Feature> installedFeatures = getInstalledFeaturesList(documentURI, libertyRuntime, libertyVersion);
-        if (installedFeatures.size() != 0) {
+        FeaturesAndPlatforms installedFeatures = getInstalledFeaturesList(documentURI, libertyRuntime, libertyVersion);
+        if (installedFeatures.getPublicFeatures().size() != 0) {
             return installedFeatures;
         }
 
         // return default list of features
-        List<Feature> defaultFeatures = getDefaultFeatures(); 
-        return defaultFeatures;
+        getDefaultFeaturesAndPlatforms(); 
+        getDefaultFeatureList();
+        return defaultFeaturesAndPlatforms;
     }
 
     public Optional<Feature> getFeature(String featureName, String libertyVersion, String libertyRuntime, int requestDelay, String documentURI) {
-        List<Feature> features = getFeatures(libertyVersion, libertyRuntime, requestDelay, documentURI);
+        FeaturesAndPlatforms fp = getFeaturesAndPlatforms(libertyVersion, libertyRuntime, requestDelay, documentURI);
+        List<Feature> features = fp.getPublicFeatures();
         return features.stream().filter(f -> f.getWlpInformation().getShortName().equalsIgnoreCase(featureName))
             .findFirst();
     }
@@ -260,7 +273,8 @@ public class FeatureService {
     }
 
     public List<Feature> getFeatureReplacements(String featureName, DOMNode featureManagerNode, String libertyVersion, String libertyRuntime, int requestDelay, String documentURI) {
-        List<Feature> features = getFeatures(libertyVersion, libertyRuntime, requestDelay, documentURI);
+        FeaturesAndPlatforms fp = getFeaturesAndPlatforms(libertyVersion, libertyRuntime, requestDelay, documentURI);
+        List<Feature> features = fp.getPublicFeatures();
         List<String> featureNamesLowerCase = getFeatureShortNames(features, true);
 
         // get list of existing features to exclude from list of possible replacements
@@ -332,17 +346,17 @@ public class FeatureService {
      * @param libertyVersion must not be null and should be a valid Liberty version (e.g. 23.0.0.6)
      * @return list of installed features, or empty list
      */
-    public List<Feature> getInstalledFeaturesList(LibertyWorkspace libertyWorkspace, String libertyRuntime, String libertyVersion) {
-        List<Feature> installedFeatures = new ArrayList<Feature>();
+    public FeaturesAndPlatforms getInstalledFeaturesAndPlatformsList(LibertyWorkspace libertyWorkspace, String libertyRuntime, String libertyVersion) {
+        FeaturesAndPlatforms installedFeaturesAndPlatforms = new FeaturesAndPlatforms();
         if (libertyWorkspace == null || libertyWorkspace.getWorkspaceString() == null) {
-            return installedFeatures;
+            return installedFeaturesAndPlatforms;
         }
 
         // return installed features from cache
-        List<Feature> cachedFeatures = libertyWorkspace.getInstalledFeatureList();
-        if (cachedFeatures.size() != 0) {
-            LOGGER.info("Getting cached features from previously generated feature list: " + cachedFeatures.size());
-            return cachedFeatures;
+        FeaturesAndPlatforms cachedFeaturesAndPlatforms = libertyWorkspace.getInstalledFeaturesAndPlatformsList();
+        if (cachedFeaturesAndPlatforms.getPublicFeatures().size() != 0) {
+            LOGGER.info("Getting cached features from previously generated feature list: " + cachedFeaturesAndPlatforms.getPublicFeatures().size());
+            return cachedFeaturesAndPlatforms;
         }
 
         try {
@@ -361,7 +375,7 @@ public class FeatureService {
 
             if (featureListFile != null && featureListFile.exists()) {
                 try {
-                    installedFeatures = readFeaturesFromFeatureListFile(installedFeatures, libertyWorkspace, featureListFile);
+                    installedFeaturesAndPlatforms = readFeaturesFromFeatureListFile(libertyWorkspace, featureListFile);
                 } catch (JAXBException e) {
                     LOGGER.severe("Error: Unable to load the generated feature list file for the target Liberty runtime due to exception: "+e.getMessage());
                 }
@@ -372,13 +386,13 @@ public class FeatureService {
             LOGGER.severe("Error: Unable to generate the feature list file from the target Liberty runtime due to exception: "+e.getMessage());
         }
 
-        LOGGER.info("Returning installed features: " + installedFeatures.size());
-        return installedFeatures;
+        LOGGER.info("Returning installed features: " + installedFeaturesAndPlatforms.getPublicFeatures().size());
+        return installedFeaturesAndPlatforms;
     }
     
-    public List<Feature> getInstalledFeaturesList(String documentURI, String libertyRuntime, String libertyVersion) {
+    public FeaturesAndPlatforms getInstalledFeaturesList(String documentURI, String libertyRuntime, String libertyVersion) {
         LibertyWorkspace libertyWorkspace = LibertyProjectsManager.getInstance().getWorkspaceFolder(documentURI);
-        return getInstalledFeaturesList(libertyWorkspace, libertyRuntime, libertyVersion);
+        return getInstalledFeaturesAndPlatformsList(libertyWorkspace, libertyRuntime, libertyVersion);
     }
 
     public FeatureListGraph getDefaultFeatureList() {
@@ -394,7 +408,7 @@ public class FeatureService {
 
             if (featureListFile != null && featureListFile.exists()) {
                 try {
-                    readFeaturesFromFeatureListFile(null, null, featureListFile, true);
+                    readFeaturesFromFeatureListFile(null, featureListFile, true);
                 } catch (JAXBException e) {
                     LOGGER.severe("Error: Unable to load the default cached featurelist file due to exception: "+e.getMessage());
                 }
@@ -481,21 +495,22 @@ public class FeatureService {
         return featureListFile;
     }
 
-    public List<Feature> readFeaturesFromFeatureListFile(List<Feature> installedFeatures, LibertyWorkspace libertyWorkspace,
+    public FeaturesAndPlatforms readFeaturesFromFeatureListFile(LibertyWorkspace libertyWorkspace,
         File featureListFile) throws JAXBException {
-            return readFeaturesFromFeatureListFile(installedFeatures, libertyWorkspace, featureListFile, false);
+            return readFeaturesFromFeatureListFile(libertyWorkspace, featureListFile, false);
     }
 
     // If the graphOnly boolean is true, the libertyWorkspace parameter may be null. Also, the defaultFeatureList should be initialized
     // after calling this method with graphOnly set to true.
-    public List<Feature> readFeaturesFromFeatureListFile(List<Feature> installedFeatures, LibertyWorkspace libertyWorkspace,
+    public FeaturesAndPlatforms readFeaturesFromFeatureListFile(LibertyWorkspace libertyWorkspace,
         File featureListFile, boolean graphOnly) throws JAXBException {
+        FeaturesAndPlatforms installedFeatures = new FeaturesAndPlatforms();
         JAXBContext jaxbContext = JAXBContext.newInstance(FeatureInfo.class);
         Unmarshaller jaxbUnmarshaller = jaxbContext.createUnmarshaller();
         FeatureInfo featureInfo = (FeatureInfo) jaxbUnmarshaller.unmarshal(featureListFile);
         FeatureListGraph featureListGraph = new FeatureListGraph();
         
-        // Note: Only the public features are loaded when unmarshalling the passed featureListFile.
+        // Note: The public features are loaded in the getFeatures() collection when unmarshalling the passed featureListFile.
         if ((featureInfo.getFeatures() != null) && (featureInfo.getFeatures().size() > 0)) {
             for (Feature f : featureInfo.getFeatures()) {
                 f.setShortDescription(f.getDescription());
@@ -525,9 +540,23 @@ public class FeatureService {
                 }
             }
 
+            // Note: The private features are loaded in the getPrivateFeatures() collection when unmarshalling the passed featureListFile.
+            List<Feature> privateFeatures = new ArrayList<>();
+            if ((featureInfo.getPrivateFeatures() != null) && (featureInfo.getPrivateFeatures().size() > 0)) {
+                for (PrivateFeature pf : featureInfo.getPrivateFeatures()) {
+                    Feature f = new Feature();
+                    f.setName(pf.getSymbolicName());
+                    WlpInformation wlpInfo = new WlpInformation(f.getName());
+                    f.setWlpInformation(wlpInfo);
+                    wlpInfo.setVisibility(LibertyConstants.PRIVATE_VISIBILITY);
+
+                    privateFeatures.add(f);
+                }
+            }
+
             if (!graphOnly) {
-                installedFeatures = featureInfo.getFeatures();
-                libertyWorkspace.setInstalledFeatureList(installedFeatures);
+                installedFeatures = new FeaturesAndPlatforms(featureInfo.getFeatures(), privateFeatures);
+                libertyWorkspace.setInstalledFeaturesAndPlatformsList(installedFeatures);
                 libertyWorkspace.setFeatureListGraph(featureListGraph);
             } else {
                 defaultFeatureList = featureListGraph;
@@ -552,13 +581,7 @@ public class FeatureService {
      * @return set of unique platforms
      */
     public Set<String> getAllPlatforms(String libertyVersion, String libertyRuntime, int requestDelay, String documentURI) {
-        List<Feature> features = this.getFeatures(libertyVersion, libertyRuntime, requestDelay, documentURI);
-        return features.stream()
-                .map(Feature::getWlpInformation)
-                .filter(Objects::nonNull)
-                .map(WlpInformation::getPlatforms)
-                .filter(Objects::nonNull)
-                .flatMap(List::stream).collect(Collectors.toSet());
+        return getFeaturesAndPlatforms(libertyVersion, libertyRuntime, requestDelay, documentURI).getPlatforms();
     }
 
     /**
@@ -590,7 +613,12 @@ public class FeatureService {
                                                      int requestDelay, String documentURI) {
         Optional<Feature> feature=this.getFeature(featureName,libertyVersion, libertyRuntime, requestDelay, documentURI);
         if (feature.isPresent() && feature.get().getWlpInformation().getPlatforms() != null) {
-            return new HashSet<>(feature.get().getWlpInformation().getPlatforms());
+            // only include available platforms - a feature can list a platform that is in beta
+            Set<String> availablePlatforms = getAllPlatforms(libertyVersion, libertyRuntime, requestDelay, documentURI);
+            Set<String> returnSet = new HashSet<>(feature.get().getWlpInformation().getPlatforms());
+            returnSet.retainAll(availablePlatforms);
+
+            return returnSet;
         }
        return Collections.emptySet();
     }

--- a/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/services/LibertyProjectsManager.java
+++ b/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/services/LibertyProjectsManager.java
@@ -143,15 +143,28 @@ public class LibertyProjectsManager {
      * @return
      */
     public LibertyWorkspace getWorkspaceFolder(String serverXMLUri) {
+        // Need to ensure the closest match is returned. A parent workspace can match the contains method below, but the variables
+        // for that workspace can be stored in the child workspace.
+        LibertyWorkspace matchingWorkspace = null;
         String normalizeUri = serverXMLUri.replace("///", "/");
         for (LibertyWorkspace folder : getInstance().getLibertyWorkspaceFolders()) {
             //Append workspaceString with file separator to avoid bad matches
             if (normalizeUri.contains(folder.getWorkspaceStringWithTrailingSlash())) {
-                return folder;
+                if (matchingWorkspace != null) {
+                    if (folder.getWorkspaceStringWithTrailingSlash().length() > matchingWorkspace.getWorkspaceStringWithTrailingSlash().length()) {
+                        // this one is a closer match so use it instead
+                        matchingWorkspace = folder;
+                    }
+                } else {
+                    matchingWorkspace = folder;
+                }
             }
         }
-        LOGGER.warning("Could not find LibertyWorkspace for file: " + serverXMLUri);
-        return null;
+
+        if (matchingWorkspace == null) {
+            LOGGER.warning("Could not find LibertyWorkspace for file: " + serverXMLUri);
+        }
+        return matchingWorkspace;
     }
 
     public void cleanUpTempDirs() {

--- a/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/services/LibertyProjectsManager.java
+++ b/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/services/LibertyProjectsManager.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2020, 2023 IBM Corporation and others.
+* Copyright (c) 2020, 2025 IBM Corporation and others.
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License v. 2.0 which is available at
@@ -148,7 +148,6 @@ public class LibertyProjectsManager {
         LibertyWorkspace matchingWorkspace = null;
         String normalizeUri = serverXMLUri.replace("///", "/");
         for (LibertyWorkspace folder : getInstance().getLibertyWorkspaceFolders()) {
-            LOGGER.info("CLK999: check workspace: "+folder.getWorkspaceString()+" for match with file URI: "+normalizeUri);
             //Append workspaceString with file separator to avoid bad matches
             if (normalizeUri.contains(folder.getWorkspaceStringWithTrailingSlash())) {
                 if (matchingWorkspace != null) {
@@ -165,7 +164,7 @@ public class LibertyProjectsManager {
         if (matchingWorkspace == null) {
             LOGGER.warning("Could not find LibertyWorkspace for file: " + serverXMLUri);
         } else {
-            LOGGER.info("CLK999: Found matching workspace: "+matchingWorkspace.getWorkspaceString()+" for file URI: "+normalizeUri);
+            LOGGER.finest("Found matching workspace: "+matchingWorkspace.getWorkspaceString()+" for file URI: "+normalizeUri);
         }
         return matchingWorkspace;
     }

--- a/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/services/LibertyProjectsManager.java
+++ b/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/services/LibertyProjectsManager.java
@@ -148,6 +148,7 @@ public class LibertyProjectsManager {
         LibertyWorkspace matchingWorkspace = null;
         String normalizeUri = serverXMLUri.replace("///", "/");
         for (LibertyWorkspace folder : getInstance().getLibertyWorkspaceFolders()) {
+            LOGGER.info("CLK999: check workspace: "+folder.getWorkspaceString()+" for match with file URI: "+normalizeUri);
             //Append workspaceString with file separator to avoid bad matches
             if (normalizeUri.contains(folder.getWorkspaceStringWithTrailingSlash())) {
                 if (matchingWorkspace != null) {
@@ -163,6 +164,8 @@ public class LibertyProjectsManager {
 
         if (matchingWorkspace == null) {
             LOGGER.warning("Could not find LibertyWorkspace for file: " + serverXMLUri);
+        } else {
+            LOGGER.info("CLK999: Found matching workspace: "+matchingWorkspace.getWorkspaceString()+" for file URI: "+normalizeUri);
         }
         return matchingWorkspace;
     }

--- a/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/services/LibertyWorkspace.java
+++ b/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/services/LibertyWorkspace.java
@@ -127,14 +127,6 @@ public class LibertyWorkspace {
         return this.libertyInstallationDir;
     }
 
-    // public List<Feature> getInstalledPublicFeatures() {
-    //     return this.installedFeaturesAndPlatformsList.getPublicFeatures();
-    // }
-
-    // public Set<String> getInstalledPlatforms() {
-    //     return this.installedFeaturesAndPlatformsList.getPlatforms();
-    // }
-
     public FeaturesAndPlatforms getInstalledFeaturesAndPlatformsList() {
         return this.installedFeaturesAndPlatformsList;
     }

--- a/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/services/LibertyWorkspace.java
+++ b/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/services/LibertyWorkspace.java
@@ -127,13 +127,13 @@ public class LibertyWorkspace {
         return this.libertyInstallationDir;
     }
 
-    public List<Feature> getInstalledPublicFeatures() {
-        return this.installedFeaturesAndPlatformsList.getPublicFeatures();
-    }
+    // public List<Feature> getInstalledPublicFeatures() {
+    //     return this.installedFeaturesAndPlatformsList.getPublicFeatures();
+    // }
 
-    public Set<String> getInstalledPlatforms() {
-        return this.installedFeaturesAndPlatformsList.getPlatforms();
-    }
+    // public Set<String> getInstalledPlatforms() {
+    //     return this.installedFeaturesAndPlatformsList.getPlatforms();
+    // }
 
     public FeaturesAndPlatforms getInstalledFeaturesAndPlatformsList() {
         return this.installedFeaturesAndPlatformsList;

--- a/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/services/LibertyWorkspace.java
+++ b/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/services/LibertyWorkspace.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2020, 2024 IBM Corporation and others.
+* Copyright (c) 2020, 2025 IBM Corporation and others.
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License v. 2.0 which is available at
@@ -18,8 +18,8 @@ import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
@@ -28,6 +28,7 @@ import jakarta.xml.bind.JAXBException;
 import jakarta.xml.bind.Unmarshaller;
 import io.openliberty.tools.langserver.lemminx.data.FeatureListGraph;
 import io.openliberty.tools.langserver.lemminx.models.feature.Feature;
+import io.openliberty.tools.langserver.lemminx.models.feature.FeaturesAndPlatforms;
 import io.openliberty.tools.langserver.lemminx.models.settings.DevcMetadata;
 
 public class LibertyWorkspace {
@@ -40,7 +41,7 @@ public class LibertyWorkspace {
     private String libertyVersion;
     private String libertyRuntime;
     private boolean isLibertyInstalled;
-    private List<Feature> installedFeatureList;
+    private FeaturesAndPlatforms installedFeaturesAndPlatformsList;
     private String libertyInstallationDir;
     private FeatureListGraph featureListGraph;
 
@@ -62,7 +63,7 @@ public class LibertyWorkspace {
         this.libertyRuntime = null;
         this.isLibertyInstalled = false;
         this.libertyInstallationDir = null;
-        this.installedFeatureList = new ArrayList<Feature>();
+        this.installedFeaturesAndPlatformsList = new FeaturesAndPlatforms();
         this.containerName = null;
         this.containerType = "docker";
         this.containerAlive = false;
@@ -110,7 +111,7 @@ public class LibertyWorkspace {
             // do not clear out the libertyRuntime or libertyVersion since those could be set for a live container
             setLibertyInstallationDir(null);
             // clear the cached feature list when Liberty is no longer installed
-            this.installedFeatureList = new ArrayList<Feature>();
+            this.installedFeaturesAndPlatformsList = new FeaturesAndPlatforms();
         }
     }
 
@@ -126,12 +127,20 @@ public class LibertyWorkspace {
         return this.libertyInstallationDir;
     }
 
-    public List<Feature> getInstalledFeatureList() {
-        return this.installedFeatureList;
+    public List<Feature> getInstalledPublicFeatures() {
+        return this.installedFeaturesAndPlatformsList.getPublicFeatures();
     }
 
-    public void setInstalledFeatureList(List<Feature> installedFeatureList) {
-        this.installedFeatureList = installedFeatureList;
+    public Set<String> getInstalledPlatforms() {
+        return this.installedFeaturesAndPlatformsList.getPlatforms();
+    }
+
+    public FeaturesAndPlatforms getInstalledFeaturesAndPlatformsList() {
+        return this.installedFeaturesAndPlatformsList;
+    }
+
+    public void setInstalledFeaturesAndPlatformsList(FeaturesAndPlatforms installedFeaturesAndPlatforms) {
+        this.installedFeaturesAndPlatformsList = installedFeaturesAndPlatforms;
     }
 
     public String getContainerName() {
@@ -239,14 +248,16 @@ public class LibertyWorkspace {
             // regenerate the feature list xml and load the FeatureListGraph.
             if (!FeatureService.getInstance().doesGeneratedFeatureListExist(this)) {
                 generateGraph = true;
-                this.setInstalledFeatureList(new ArrayList<Feature> ()); // clear out cached feature list
+                // clear out cached feature list
+                this.installedFeaturesAndPlatformsList = new FeaturesAndPlatforms();
+
             }
         }
 
         if (generateGraph) {
             if (isLibertyInstalled || isContainerAlive()) {
                 LOGGER.info("Generating installed features list and storing to cache for workspace " + workspaceFolderURI);
-                FeatureService.getInstance().getInstalledFeaturesList(this, libertyRuntime, libertyVersion);
+                FeatureService.getInstance().getInstalledFeaturesAndPlatformsList(this, libertyRuntime, libertyVersion);
                 useFeatureListGraph = this.featureListGraph;
             } else {
                  LOGGER.info("Retrieving default cached feature list for workspace " + workspaceFolderURI);

--- a/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/services/SettingsService.java
+++ b/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/services/SettingsService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2020, 2022 IBM Corporation and others.
+* Copyright (c) 2020, 2025 IBM Corporation and others.
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License v. 2.0 which is available at
@@ -136,13 +136,7 @@ public class SettingsService {
             LOGGER.warning("Could not find workspace for server xml URI %s. Variable resolution cannot be performed.".formatted(serverXmlURI));
         } else if (variables != null && variables.containsKey(workspace.getWorkspaceString())) {
             variableProps = variables.get(workspace.getWorkspaceString());
-            if (variableProps == null) {
-                LOGGER.warning("CLK999: Could not find variable properties for workspace URI %s. Variable resolution cannot be performed.".formatted(workspace.getWorkspaceString()));
-            }
         } else {
-            if (variables == null) {
-                LOGGER.warning("CLK999: Could not find variables for workspace URI %s. Variable resolution cannot be performed.".formatted(workspace.getWorkspaceString()));
-            }
             LOGGER.warning("Could not find variable mapping for workspace URI %s. Variable resolution cannot be performed.".formatted(workspace.getWorkspaceString()));
         }
         return variableProps;

--- a/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/services/SettingsService.java
+++ b/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/services/SettingsService.java
@@ -132,12 +132,15 @@ public class SettingsService {
         Properties variableProps = new Properties();
         if (workspace == null) {
             LOGGER.warning("Could not find workspace for server xml URI %s. Variable resolution cannot be performed.".formatted(serverXmlURI));
-        } else if (variables.containsKey(workspace.getWorkspaceString())) {
+        } else if (variables != null && variables.containsKey(workspace.getWorkspaceString())) {
             variableProps = variables.get(workspace.getWorkspaceString());
             if (variableProps == null) {
                 LOGGER.warning("CLK999: Could not find variable properties for workspace URI %s. Variable resolution cannot be performed.".formatted(workspace.getWorkspaceString()));
             }
         } else {
+            if (variables == null) {
+                LOGGER.warning("CLK999: Could not find variables for workspace URI %s. Variable resolution cannot be performed.".formatted(workspace.getWorkspaceString()));
+            }
             LOGGER.warning("Could not find variable mapping for workspace URI %s. Variable resolution cannot be performed.".formatted(workspace.getWorkspaceString()));
         }
         return variableProps;

--- a/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/services/SettingsService.java
+++ b/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/services/SettingsService.java
@@ -110,7 +110,7 @@ public class SettingsService {
                             new CommonLogger(LOGGER), null, installDirectory, userDirectory, serverDirectory);
                     variablesForWorkspace.putAll(serverConfigDocument.getDefaultProperties());
                     variablesForWorkspace.putAll(serverConfigDocument.getProperties());
-                    LOGGER.info("CLK999: Populated variables for workspace: "+workspace.getWorkspaceString()+". Number of variables found: "+variablesForWorkspace.size());
+                    LOGGER.finest("Populated variables for workspace: "+workspace.getWorkspaceString()+". Number of variables found: "+variablesForWorkspace.size());
                 } catch (Exception e) {
                     LOGGER.warning("Variable resolution is not available because the necessary directory locations were not found in the liberty-plugin-config.xml file.");
                     LOGGER.info("Exception received: " + e.getMessage());
@@ -119,7 +119,6 @@ public class SettingsService {
         } else {
             LOGGER.warning("Could not find liberty-plugin-config.xml in workspace URI " + workspace.getWorkspaceString() + ". Variable resolution cannot be performed");
         }
-        LOGGER.info("CLK999: Populated variable map for workspace: "+workspace.getWorkspaceString());
         variables.put(workspace.getWorkspaceString(), variablesForWorkspace);
     }
 

--- a/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/services/SettingsService.java
+++ b/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/services/SettingsService.java
@@ -134,6 +134,9 @@ public class SettingsService {
             LOGGER.warning("Could not find workspace for server xml URI %s. Variable resolution cannot be performed.".formatted(serverXmlURI));
         } else if (variables.containsKey(workspace.getWorkspaceString())) {
             variableProps = variables.get(workspace.getWorkspaceString());
+            if (variableProps == null) {
+                LOGGER.warning("CLK999: Could not find variable properties for workspace URI %s. Variable resolution cannot be performed.".formatted(workspace.getWorkspaceString()));
+            }
         } else {
             LOGGER.warning("Could not find variable mapping for workspace URI %s. Variable resolution cannot be performed.".formatted(workspace.getWorkspaceString()));
         }

--- a/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/services/SettingsService.java
+++ b/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/services/SettingsService.java
@@ -110,7 +110,7 @@ public class SettingsService {
                             new CommonLogger(LOGGER), null, installDirectory, userDirectory, serverDirectory);
                     variablesForWorkspace.putAll(serverConfigDocument.getDefaultProperties());
                     variablesForWorkspace.putAll(serverConfigDocument.getProperties());
-                    LOGGER.finest("Populated variables for workspace: "+workspace.getWorkspaceString()+". Number of variables found: "+variablesForWorkspace.size());
+                    LOGGER.finest("Populated variables for workspace: " + workspace.getWorkspaceString() + ". Number of variables found: " + variablesForWorkspace.size());
                 } catch (Exception e) {
                     LOGGER.warning("Variable resolution is not available because the necessary directory locations were not found in the liberty-plugin-config.xml file.");
                     LOGGER.info("Exception received: " + e.getMessage());

--- a/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/services/SettingsService.java
+++ b/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/services/SettingsService.java
@@ -110,6 +110,7 @@ public class SettingsService {
                             new CommonLogger(LOGGER), null, installDirectory, userDirectory, serverDirectory);
                     variablesForWorkspace.putAll(serverConfigDocument.getDefaultProperties());
                     variablesForWorkspace.putAll(serverConfigDocument.getProperties());
+                    LOGGER.info("CLK999: Populated variables for workspace: "+workspace.getWorkspaceString()+". Number of variables found: "+variablesForWorkspace.size());
                 } catch (Exception e) {
                     LOGGER.warning("Variable resolution is not available because the necessary directory locations were not found in the liberty-plugin-config.xml file.");
                     LOGGER.info("Exception received: " + e.getMessage());
@@ -118,6 +119,7 @@ public class SettingsService {
         } else {
             LOGGER.warning("Could not find liberty-plugin-config.xml in workspace URI " + workspace.getWorkspaceString() + ". Variable resolution cannot be performed");
         }
+        LOGGER.info("CLK999: Populated variable map for workspace: "+workspace.getWorkspaceString());
         variables.put(workspace.getWorkspaceString(), variablesForWorkspace);
     }
 

--- a/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/util/LibertyConstants.java
+++ b/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/util/LibertyConstants.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2020, 2024 IBM Corporation and others.
+* Copyright (c) 2020, 2025 IBM Corporation and others.
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License v. 2.0 which is available at
@@ -31,6 +31,7 @@ public final class LibertyConstants {
     public static final String INCLUDE_ELEMENT = "include";
     public static final String PLATFORM_ELEMENT = "platform";
     public static final String PUBLIC_VISIBILITY = "PUBLIC";
+    public static final String PRIVATE_VISIBILITY = "PRIVATE";
 
     // following URI standard of using "/"
     public static final String WLP_USER_CONFIG_DIR = "/usr/shared/config/";

--- a/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/util/LibertyUtils.java
+++ b/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/util/LibertyUtils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2020, 2024 IBM Corporation and others.
+* Copyright (c) 2020, 2025 IBM Corporation and others.
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License v. 2.0 which is available at
@@ -35,7 +35,7 @@ import io.openliberty.tools.langserver.lemminx.models.feature.VariableLoc;
 import org.eclipse.lemminx.dom.DOMDocument;
 
 import io.openliberty.tools.langserver.lemminx.data.LibertyRuntime;
-import io.openliberty.tools.langserver.lemminx.models.feature.Feature;
+import io.openliberty.tools.langserver.lemminx.models.feature.FeaturesAndPlatforms;
 import io.openliberty.tools.langserver.lemminx.models.settings.DevcMetadata;
 import io.openliberty.tools.langserver.lemminx.services.ContainerService;
 import io.openliberty.tools.langserver.lemminx.services.LibertyProjectsManager;
@@ -347,7 +347,7 @@ public class LibertyUtils {
             // new properties file, reset the installed features stored in the feature cache
             // so that the installed features list will be regenerated as it may have
             // changed between Liberty installations
-            libertyWorkspace.setInstalledFeatureList(new ArrayList<Feature>());
+            libertyWorkspace.setInstalledFeaturesAndPlatformsList(new FeaturesAndPlatforms());
 
             // add a file watcher on this file
             if (!libertyWorkspace.isLibertyInstalled() || updateRuntimeInfo) {

--- a/lemminx-liberty/src/test/java/io/openliberty/LibertyCompletionTest.java
+++ b/lemminx-liberty/src/test/java/io/openliberty/LibertyCompletionTest.java
@@ -168,7 +168,23 @@ public class LibertyCompletionTest {
                         "       </featureManager>", //
                         "</server>" //
                 );
-                XMLAssert.testCompletionFor(serverXML, null, serverXMLURI, 5);
+
+                //CompletionItem jakartaee11Completion = c("jakartaee-11.0", "jakartaee-11.0"); // this is in beta and should not be included yet
+                CompletionItem jakartaee10Completion = c("jakartaee-10.0", "jakartaee-10.0");
+                CompletionItem jakartaee91Completion = c("jakartaee-9.1", "jakartaee-9.1");
+                CompletionItem jakartaee80Completion = c("jakartaee-8.0", "jakartaee-8.0");
+
+                XMLAssert.testCompletionFor(serverXML, null, serverXMLURI, 5, jakartaee80Completion, jakartaee91Completion, jakartaee10Completion);
+
+                serverXML = String.join(newLine, //
+                        "<server description=\"Sample Liberty server\">", //
+                        "       <featureManager>", //
+                        "               <platform>jakartaee-11|</platform>", //
+                        "       </featureManager>", //
+                        "</server>" //
+                );
+
+                XMLAssert.testCompletionFor(serverXML, null, serverXMLURI, 2);  // one for CDATA and one for <-, no completion for jakartaee-11.0
 
                 serverXML = String.join(newLine, //
                         "<server description=\"Sample Liberty server\">", //

--- a/lemminx-liberty/src/test/java/io/openliberty/LibertyDiagnosticTest.java
+++ b/lemminx-liberty/src/test/java/io/openliberty/LibertyDiagnosticTest.java
@@ -17,7 +17,6 @@ import org.junit.jupiter.api.Test;
 
 import io.openliberty.tools.langserver.lemminx.LibertyDiagnosticParticipant;
 import io.openliberty.tools.langserver.lemminx.data.FeatureListGraph;
-import io.openliberty.tools.langserver.lemminx.models.feature.Feature;
 import io.openliberty.tools.langserver.lemminx.services.FeatureService;
 import io.openliberty.tools.langserver.lemminx.services.LibertyProjectsManager;
 import io.openliberty.tools.langserver.lemminx.services.LibertyWorkspace;
@@ -331,7 +330,7 @@ public class LibertyDiagnosticTest {
     @Test
     public void testConfigElementMissingFeatureManager() throws JAXBException {
         assertTrue(featureList.exists());
-        FeatureService.getInstance().readFeaturesFromFeatureListFile(new ArrayList<Feature>(), libWorkspace, featureList);
+        FeatureService.getInstance().readFeaturesFromFeatureListFile(libWorkspace, featureList);
 
         String serverXml = "<server><ssl id=\"\"/></server>";
         // Temporarily disabling config element diagnostics if featureManager element is missing (until issue 230 is addressed)
@@ -403,7 +402,7 @@ public class LibertyDiagnosticTest {
     @Test
     public void testConfigElementDirect() throws JAXBException {
         assertTrue(featureList.exists());
-        FeatureService.getInstance().readFeaturesFromFeatureListFile(new ArrayList<Feature>(), libWorkspace, featureList);
+        FeatureService.getInstance().readFeaturesFromFeatureListFile(libWorkspace, featureList);
 
         String correctFeature   = "           <feature>Ssl-1.0</feature>";
         String incorrectFeature = "           <feature>jaxrs-2.0</feature>";
@@ -441,7 +440,7 @@ public class LibertyDiagnosticTest {
     @Test
     public void testConfigElementTransitive() throws JAXBException {
         assertTrue(featureList.exists());
-        FeatureService.getInstance().readFeaturesFromFeatureListFile(new ArrayList<Feature>(), libWorkspace, featureList);
+        FeatureService.getInstance().readFeaturesFromFeatureListFile(libWorkspace, featureList);
         String serverXML1 = String.join(newLine,
                 "<server description=\"Sample Liberty server\">",
                 "   <featureManager>",
@@ -694,7 +693,7 @@ public class LibertyDiagnosticTest {
     @Test
     public void testConfigElementVersionLess() throws JAXBException {
         assertTrue(featureList.exists());
-        FeatureService.getInstance().readFeaturesFromFeatureListFile(new ArrayList<Feature>(), libWorkspace, featureList);
+        FeatureService.getInstance().readFeaturesFromFeatureListFile(libWorkspace, featureList);
         String serverXML1 = String.join(newLine,
                 "<server description=\"Sample Liberty server\">",
                 "   <featureManager>",

--- a/lemminx-liberty/src/test/java/io/openliberty/LibertyDiagnosticTest.java
+++ b/lemminx-liberty/src/test/java/io/openliberty/LibertyDiagnosticTest.java
@@ -464,6 +464,7 @@ public class LibertyDiagnosticTest {
                 "               <platform>javaee-7.0</platform>", //
                 "               <platform>javaee-8.0</platform>", //
                 "               <platform>jakartaee-9.1</platform>", //
+                "               <platform>jakartaee-11.0</platform>", //
                 "       </featureManager>", //
                 "</server>" //
         );
@@ -485,9 +486,14 @@ public class LibertyDiagnosticTest {
         invalid4.setRange(r(8, 25, 8, 38));
         invalid4.setMessage("ERROR: The following configured platform versions are in conflict [javaee-7.0, javaee-8.0, jakartaee-9.1]");
 
+        Diagnostic invalid5 = new Diagnostic();
+        invalid5.setRange(r(9, 25, 9, 39));
+        invalid5.setCode(LibertyDiagnosticParticipant.INCORRECT_PLATFORM_CODE);
+        invalid5.setMessage("ERROR: The platform \"jakartaee-11.0\" does not exist."); // beta platform should not be valid
+
 
         XMLAssert.testDiagnosticsFor(serverXML, null, null, serverXMLURI,
-                invalid1, invalid2, invalid3, invalid4);
+                invalid1, invalid2, invalid3, invalid4, invalid5);
     }
 
     @Test

--- a/lemminx-liberty/src/test/java/io/openliberty/LibertyFeatureTest.java
+++ b/lemminx-liberty/src/test/java/io/openliberty/LibertyFeatureTest.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.Test;
 
 import io.openliberty.tools.langserver.lemminx.data.FeatureListGraph;
 import io.openliberty.tools.langserver.lemminx.models.feature.Feature;
+import io.openliberty.tools.langserver.lemminx.models.feature.FeaturesAndPlatforms;
 import io.openliberty.tools.langserver.lemminx.services.FeatureService;
 import io.openliberty.tools.langserver.lemminx.services.LibertyProjectsManager;
 import io.openliberty.tools.langserver.lemminx.services.LibertyWorkspace;
@@ -37,11 +38,11 @@ public class LibertyFeatureTest {
 
         LibertyWorkspace libWorkspace = workspaceFolders.iterator().next();
 
-        List<Feature> installedFeatures = new ArrayList<Feature>();
-        installedFeatures = fs.readFeaturesFromFeatureListFile(installedFeatures, libWorkspace, featureListFile);
+        FeaturesAndPlatforms fp = fs.readFeaturesFromFeatureListFile(libWorkspace, featureListFile);
+        List<Feature> installedFeatures = fp.getPublicFeatures();
         
         assertFalse(installedFeatures.isEmpty());
-        assertTrue(installedFeatures.equals(libWorkspace.getInstalledFeatureList()));
+        assertTrue(installedFeatures.equals(libWorkspace.getInstalledFeaturesAndPlatformsList().getPublicFeatures()));
         // Check that list contains a beta feature
         assertTrue(installedFeatures.removeIf(f -> (f.getName().equals("cdi-4.0"))));
 

--- a/lemminx-liberty/src/test/java/io/openliberty/SettingsServiceTest.java
+++ b/lemminx-liberty/src/test/java/io/openliberty/SettingsServiceTest.java
@@ -39,6 +39,7 @@ public class SettingsServiceTest {
     @BeforeEach
     public void setupWorkspace() {
         initList.add(new WorkspaceFolder(resourcesDir.toURI().toString()));
+        initList.add(new WorkspaceFolder(resourcesLibertyDir.toURI().toString()));
         libPM = LibertyProjectsManager.getInstance();
         libPM.setWorkspaceFolders(initList);
         libWorkspace = libPM.getLibertyWorkspaceFolders().iterator().next();

--- a/lemminx-liberty/src/test/java/io/openliberty/SettingsServiceTest.java
+++ b/lemminx-liberty/src/test/java/io/openliberty/SettingsServiceTest.java
@@ -39,7 +39,7 @@ public class SettingsServiceTest {
     @BeforeEach
     public void setupWorkspace() {
         initList.add(new WorkspaceFolder(resourcesDir.toURI().toString()));
-        initList.add(new WorkspaceFolder(resourcesLibertyDir.toURI().toString()));
+        initList.add(new WorkspaceFolder(resourcesLibertyDir.toURI().toString())); // initialize workspace that test method uses also
         libPM = LibertyProjectsManager.getInstance();
         libPM.setWorkspaceFolders(initList);
         libWorkspace = libPM.getLibertyWorkspaceFolders().iterator().next();

--- a/lemminx-liberty/src/test/java/io/openliberty/SettingsServiceTest.java
+++ b/lemminx-liberty/src/test/java/io/openliberty/SettingsServiceTest.java
@@ -27,6 +27,7 @@ public class SettingsServiceTest {
     File resourcesDir = new File("src/test/resources/serverConfig");
     File resourcesLibertyDir = new File("src/test/resources/serverConfig", "liberty");
     File serverDir = new File("src/test/resources/serverConfig/liberty/wlp/usr/servers/defaultServer");
+    File serverXmlFile = new File(serverDir,"server.xml");
     File installDir = new File("src/test/resources/serverConfig/liberty/wlp");
     File userDir = new File("src/test/resources/serverConfig/liberty/wlp/usr");
 
@@ -62,7 +63,7 @@ public class SettingsServiceTest {
         List<LibertyWorkspace> initList = new ArrayList<>();
         initList.add(new LibertyWorkspace(resourcesLibertyDir.toURI().toString()));
         SettingsService.getInstance().populateAllVariables(initList);
-        Properties variables = SettingsService.getInstance().getVariablesForServerXml(resourcesLibertyDir.toURI().toString());
+        Properties variables = SettingsService.getInstance().getVariablesForServerXml(serverXmlFile.toURI().toString()); // point to a file not a workspace dir
 
         assertNotNull(variables);
         // bootstrap.properties.override added in server.env and bootstrap.properties

--- a/lemminx-liberty/src/test/java/io/openliberty/SettingsServiceTest.java
+++ b/lemminx-liberty/src/test/java/io/openliberty/SettingsServiceTest.java
@@ -63,6 +63,7 @@ public class SettingsServiceTest {
     public void testPopulateAllVariables() throws IOException {
         List<LibertyWorkspace> initList = new ArrayList<>();
         initList.add(new LibertyWorkspace(resourcesLibertyDir.toURI().toString()));
+        initList.add(new LibertyWorkspace(installDir.toURI().toString()));
         SettingsService.getInstance().populateAllVariables(initList);
         Properties variables = SettingsService.getInstance().getVariablesForServerXml(serverXmlFile.toURI().toString()); // point to a file not a workspace dir
 


### PR DESCRIPTION
Fix for https://github.com/OpenLiberty/liberty-tools-intellij/issues/1229

The platforms are currently collected from the public features in features.json. Those happen to include beta platforms and there is no direct way to determine that the platform is in beta.

This PR instead uses the private features to collect platforms. Only the "compatability" private features contain a reference to their platforms. Beta platforms are not part of any compatability features.

For example, features.json contains the following snippet for a private feature for compatability for jakartaee-10.0:

```
            "platforms": [
                "jakartaee-10.0"
            ],
            "provideFeature": [
                "com.ibm.websphere.appserver.eeCompatible-10.0"
            ],
            "singleton": "true",
            "typeLabel": "Feature",
            "vanityRelativeURL": "features-com.ibm.websphere.appserver.eeCompatible-10.0",
            "visibility": "PRIVATE",
```