### PR TITLE
Liberty config plugin file validation for proper variables validation

### DIFF
--- a/lemminx-liberty/src/it/variable-processing-ol-it/src/test/java/LibertyWorkspaceIT.java
+++ b/lemminx-liberty/src/it/variable-processing-ol-it/src/test/java/LibertyWorkspaceIT.java
@@ -6,6 +6,8 @@ import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
 
+import io.openliberty.tools.langserver.lemminx.services.LibertyWorkspace;
+import io.openliberty.tools.langserver.lemminx.services.SettingsService;
 import org.eclipse.lemminx.XMLAssert;
 import org.eclipse.lemminx.commons.BadLocationException;
 import org.eclipse.lsp4j.CodeAction;
@@ -42,6 +44,10 @@ public class LibertyWorkspaceIT {
         List<WorkspaceFolder> testWorkspaceFolders = new ArrayList<WorkspaceFolder>();
         testWorkspaceFolders.add(testWorkspace);
         LibertyProjectsManager.getInstance().setWorkspaceFolders(testWorkspaceFolders);
+
+        // Assert that the liberty plugin config is copied to the server
+        LibertyWorkspace workspace = LibertyProjectsManager.getInstance().getWorkspaceFolder(testWorkspace.getUri());
+        assert SettingsService.getInstance().isLibertyPluginConfigAvailableInServer(workspace);
 
         String serverXML = String.join(newLine, //
                 "<server description=\"Sample Liberty server\">", //

--- a/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/LibertyDiagnosticParticipant.java
+++ b/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/LibertyDiagnosticParticipant.java
@@ -103,14 +103,13 @@ public class LibertyDiagnosticParticipant implements IDiagnosticsParticipant {
             }
         }
         validateConfigElements(domDocument, diagnosticsList, tempDiagnosticsList, featureGraph, includedFeatures, featureManagerPresent);
-        validateVariables(domDocument,diagnosticsList);
+        validateVariables(domDocument, diagnosticsList, workspace);
     }
 
-    private void validateVariables(DOMDocument domDocument, List<Diagnostic> diagnosticsList) {
+    private void validateVariables(DOMDocument domDocument, List<Diagnostic> diagnosticsList, LibertyWorkspace workspace) {
         String docContent = domDocument.getTextDocument().getText();
         List<VariableLoc> variables = LibertyUtils.getVariablesFromTextContent(docContent);
         Properties variablesMap = SettingsService.getInstance().getVariablesForServerXml(domDocument.getDocumentURI());
-        LibertyWorkspace workspace = LibertyProjectsManager.getInstance().getWorkspaceFolder(domDocument.getDocumentURI());
 
         // Check if the liberty plugin config has been copied to the server or not.
         // SettingsService have a setConfigCopiedToServer method, which is setting up after this check for a different purpose, so it can't be used from here

--- a/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/LibertyDiagnosticParticipant.java
+++ b/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/LibertyDiagnosticParticipant.java
@@ -110,8 +110,13 @@ public class LibertyDiagnosticParticipant implements IDiagnosticsParticipant {
         String docContent = domDocument.getTextDocument().getText();
         List<VariableLoc> variables = LibertyUtils.getVariablesFromTextContent(docContent);
         Properties variablesMap = SettingsService.getInstance().getVariablesForServerXml(domDocument.getDocumentURI());
-        if (variablesMap.isEmpty() && !variables.isEmpty()) {
-            LibertyWorkspace workspace = LibertyProjectsManager.getInstance().getWorkspaceFolder(domDocument.getDocumentURI());
+        LibertyWorkspace workspace = LibertyProjectsManager.getInstance().getWorkspaceFolder(domDocument.getDocumentURI());
+
+        // Check if the liberty plugin config has been copied to the server or not.
+        // SettingsService have a setConfigCopiedToServer method, which is setting up after this check for a different purpose, so it can't be used from here
+        boolean isLibertyPluginConfigAvailableInServer = SettingsService.getInstance().isLibertyPluginConfigAvailableInServer(workspace);
+
+        if ((variablesMap.isEmpty() || !isLibertyPluginConfigAvailableInServer) && !variables.isEmpty()) {
             String message = ResourceBundleUtil.getMessage(ResourceBundleMappingConstants.WARN_VARIABLE_RESOLUTION_NOT_AVAILABLE, workspace.getWorkspaceURI().getPath());
             Range range = XMLPositionUtility.createRange(domDocument.getDocumentElement().getStartTagOpenOffset(), domDocument.getDocumentElement().getStartTagCloseOffset(),
                     domDocument);

--- a/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/services/SettingsService.java
+++ b/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/services/SettingsService.java
@@ -170,4 +170,13 @@ public class SettingsService {
                 new Locale("es", "ES")
         );
     }
+
+    // Check if the liberty-plugin-config.xml is copied to server or not
+    public boolean isLibertyPluginConfigAvailableInServer(LibertyWorkspace libertyWorkspace) {
+        if (libertyWorkspace != null) {
+            Path pluginConfigFilePath = LibertyUtils.findFileInWorkspace(libertyWorkspace, Paths.get("liberty-plugin-config.xml"));
+            return pluginConfigFilePath != null;
+        }
+        return false;
+    }
 }

--- a/lemminx-liberty/src/test/java/io/openliberty/LibertyDiagnosticTest.java
+++ b/lemminx-liberty/src/test/java/io/openliberty/LibertyDiagnosticTest.java
@@ -922,6 +922,7 @@ public class LibertyDiagnosticTest {
         Properties props = new Properties();
         props.putAll(propsMap);
         when(settingsService.getVariablesForServerXml(any())).thenReturn(props);
+        when(settingsService.isLibertyPluginConfigAvailableInServer(any())).thenReturn(true);
         Diagnostic dup1 = new Diagnostic();
         dup1.setRange(r(7, 29, 7, 50));
         dup1.setCode(LibertyDiagnosticParticipant.INCORRECT_VARIABLE_CODE);
@@ -951,6 +952,7 @@ public class LibertyDiagnosticTest {
         Properties props = new Properties();
         props.putAll(propsMap);
         when(settingsService.getVariablesForServerXml(any())).thenReturn(props);
+        when(settingsService.isLibertyPluginConfigAvailableInServer(any())).thenReturn(true);
         Diagnostic invalid1 = new Diagnostic();
         invalid1.setRange(r(7, 29, 7, 45));
         invalid1.setCode(LibertyDiagnosticParticipant.INCORRECT_VARIABLE_CODE);
@@ -1032,6 +1034,7 @@ public class LibertyDiagnosticTest {
         Properties props = new Properties();
         props.putAll(propsMap);
         when(settingsService.getVariablesForServerXml(any())).thenReturn(props);
+        when(settingsService.isLibertyPluginConfigAvailableInServer(any())).thenReturn(true);
         Diagnostic dup1 = new Diagnostic();
         dup1.setRange(r(5, 34, 5, 55));
         dup1.setCode(LibertyDiagnosticParticipant.INCORRECT_VARIABLE_CODE);
@@ -1071,6 +1074,7 @@ public class LibertyDiagnosticTest {
         Properties props = new Properties();
         props.putAll(propsMap);
         when(settingsService.getVariablesForServerXml(any())).thenReturn(props);
+        when(settingsService.isLibertyPluginConfigAvailableInServer(any())).thenReturn(true);
         Diagnostic dup1 = new Diagnostic();
         dup1.setRange(r(8, 63, 8, 74));
         dup1.setCode(LibertyDiagnosticParticipant.INCORRECT_VARIABLE_CODE);
@@ -1227,6 +1231,7 @@ public class LibertyDiagnosticTest {
         Properties props = new Properties();
         props.putAll(propsMap);
         when(settingsService.getVariablesForServerXml(any())).thenReturn(props);
+        when(settingsService.isLibertyPluginConfigAvailableInServer(any())).thenReturn(true);
         Diagnostic invalid1 = new Diagnostic();
         invalid1.setRange(r(5, 1, 5, 33));
         invalid1.setCode(LibertyDiagnosticParticipant.INCORRECT_VARIABLE_CODE);
@@ -1256,6 +1261,7 @@ public class LibertyDiagnosticTest {
         Properties props = new Properties();
         props.putAll(propsMap);
         when(settingsService.getVariablesForServerXml(any())).thenReturn(props);
+        when(settingsService.isLibertyPluginConfigAvailableInServer(any())).thenReturn(true);
         Diagnostic invalid1 = new Diagnostic();
         invalid1.setRange(r(5, 1, 5, 37));
         invalid1.setCode(LibertyDiagnosticParticipant.INCORRECT_VARIABLE_CODE);
@@ -1285,6 +1291,7 @@ public class LibertyDiagnosticTest {
         Properties props = new Properties();
         props.putAll(propsMap);
         when(settingsService.getVariablesForServerXml(any())).thenReturn(props);
+        when(settingsService.isLibertyPluginConfigAvailableInServer(any())).thenReturn(true);
         Diagnostic invalid1 = new Diagnostic();
         invalid1.setRange(r(5, 1, 5, 44));
         invalid1.setCode(LibertyDiagnosticParticipant.INCORRECT_VARIABLE_CODE);

--- a/lemminx-liberty/src/test/java/io/openliberty/LibertyDiagnosticTest.java
+++ b/lemminx-liberty/src/test/java/io/openliberty/LibertyDiagnosticTest.java
@@ -76,6 +76,7 @@ public class LibertyDiagnosticTest {
         settings.when(SettingsService::getInstance).thenReturn(settingsService);
         Mockito.lenient().when(settingsService.getVariablesForServerXml(any())).thenReturn(new Properties());
         Mockito.lenient().when(settingsService.getCurrentLocale()).thenReturn(Locale.getDefault());
+        Mockito.lenient().when(settingsService.isLibertyPluginConfigAvailableInServer(any())).thenReturn(true);
         MISSING_CONFIGURED_FEATURE_MESSAGE = ResourceBundleUtil.getMessage(ResourceBundleMappingConstants.ERR_MISSING_CONFIGURED_FEATURE_MESSAGE);
     }
 
@@ -922,7 +923,6 @@ public class LibertyDiagnosticTest {
         Properties props = new Properties();
         props.putAll(propsMap);
         when(settingsService.getVariablesForServerXml(any())).thenReturn(props);
-        when(settingsService.isLibertyPluginConfigAvailableInServer(any())).thenReturn(true);
         Diagnostic dup1 = new Diagnostic();
         dup1.setRange(r(7, 29, 7, 50));
         dup1.setCode(LibertyDiagnosticParticipant.INCORRECT_VARIABLE_CODE);
@@ -952,7 +952,6 @@ public class LibertyDiagnosticTest {
         Properties props = new Properties();
         props.putAll(propsMap);
         when(settingsService.getVariablesForServerXml(any())).thenReturn(props);
-        when(settingsService.isLibertyPluginConfigAvailableInServer(any())).thenReturn(true);
         Diagnostic invalid1 = new Diagnostic();
         invalid1.setRange(r(7, 29, 7, 45));
         invalid1.setCode(LibertyDiagnosticParticipant.INCORRECT_VARIABLE_CODE);
@@ -1018,6 +1017,38 @@ public class LibertyDiagnosticTest {
     }
 
     @Test
+    public void testNoPluginConfigAvailableDiagnostic() throws IOException {
+        String serverXML = String.join(newLine, //
+                "<server description=\"Sample Liberty server\">", //
+                "       <featureManager>", //
+                "                <platform>javaee-6.0</platform>", //
+                "                <feature>acmeCA-2.0</feature>", //
+                "       </featureManager>", //
+                " <variable name=\"httpPort\" value=\"9080\"/>", //
+                " <variable name=\"httpPort\" value=\"9443\"/>", //
+                " <httpEndpoint host=\"*\" httpPort=\"${default.http.port}\"\n",//
+                "                  httpsPort=\"${default.https.port}\" id=\"defaultHttpEndpoint\"/>",//
+                "</server>" //
+        );
+        Map<String, String> propsMap = new HashMap<>();
+        propsMap.put("default.http.port", "9080");
+        propsMap.put("default.https.port", "9443");
+        Properties props = new Properties();
+        props.putAll(propsMap);
+        when(settingsService.getVariablesForServerXml(any())).thenReturn(props);
+        when(settingsService.isLibertyPluginConfigAvailableInServer(any())).thenReturn(false);
+
+        Diagnostic dup1 = new Diagnostic();
+        dup1.setRange(r(0, 0, 0, 43));
+        String message="WARNING: Variable resolution is not available for workspace %s. Please start the Liberty server for the workspace to enable variable resolution.";
+        dup1.setMessage(message.formatted(srcResourcesDir.toURI().getPath()));
+        dup1.setSeverity(DiagnosticSeverity.Warning);
+        dup1.setSource("liberty-lemminx");
+
+        XMLAssert.testDiagnosticsFor(serverXML, null, null, serverXMLURI, false, dup1);
+    }
+
+    @Test
     public void testInvalidVariableRepeatedDiagnostic() {
         String serverXML = String.join(newLine, //
                 "<server description=\"Sample Liberty server\">", //
@@ -1034,7 +1065,6 @@ public class LibertyDiagnosticTest {
         Properties props = new Properties();
         props.putAll(propsMap);
         when(settingsService.getVariablesForServerXml(any())).thenReturn(props);
-        when(settingsService.isLibertyPluginConfigAvailableInServer(any())).thenReturn(true);
         Diagnostic dup1 = new Diagnostic();
         dup1.setRange(r(5, 34, 5, 55));
         dup1.setCode(LibertyDiagnosticParticipant.INCORRECT_VARIABLE_CODE);
@@ -1074,7 +1104,6 @@ public class LibertyDiagnosticTest {
         Properties props = new Properties();
         props.putAll(propsMap);
         when(settingsService.getVariablesForServerXml(any())).thenReturn(props);
-        when(settingsService.isLibertyPluginConfigAvailableInServer(any())).thenReturn(true);
         Diagnostic dup1 = new Diagnostic();
         dup1.setRange(r(8, 63, 8, 74));
         dup1.setCode(LibertyDiagnosticParticipant.INCORRECT_VARIABLE_CODE);
@@ -1231,7 +1260,6 @@ public class LibertyDiagnosticTest {
         Properties props = new Properties();
         props.putAll(propsMap);
         when(settingsService.getVariablesForServerXml(any())).thenReturn(props);
-        when(settingsService.isLibertyPluginConfigAvailableInServer(any())).thenReturn(true);
         Diagnostic invalid1 = new Diagnostic();
         invalid1.setRange(r(5, 1, 5, 33));
         invalid1.setCode(LibertyDiagnosticParticipant.INCORRECT_VARIABLE_CODE);
@@ -1261,7 +1289,6 @@ public class LibertyDiagnosticTest {
         Properties props = new Properties();
         props.putAll(propsMap);
         when(settingsService.getVariablesForServerXml(any())).thenReturn(props);
-        when(settingsService.isLibertyPluginConfigAvailableInServer(any())).thenReturn(true);
         Diagnostic invalid1 = new Diagnostic();
         invalid1.setRange(r(5, 1, 5, 37));
         invalid1.setCode(LibertyDiagnosticParticipant.INCORRECT_VARIABLE_CODE);
@@ -1291,7 +1318,6 @@ public class LibertyDiagnosticTest {
         Properties props = new Properties();
         props.putAll(propsMap);
         when(settingsService.getVariablesForServerXml(any())).thenReturn(props);
-        when(settingsService.isLibertyPluginConfigAvailableInServer(any())).thenReturn(true);
         Diagnostic invalid1 = new Diagnostic();
         invalid1.setRange(r(5, 1, 5, 44));
         invalid1.setCode(LibertyDiagnosticParticipant.INCORRECT_VARIABLE_CODE);


### PR DESCRIPTION
This is a fix for issue #358 

Introduced a new method to check if the liberty-plugin-config.xml is present or not
This check is added at the variables validation to do the diagnostic 