### PR TITLE
Line separator issue in Feature Hover content

### DIFF
--- a/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/LibertyHoverParticipant.java
+++ b/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/LibertyHoverParticipant.java
@@ -40,6 +40,7 @@ import java.util.logging.Logger;
 
 public class LibertyHoverParticipant implements IHoverParticipant {
     private static final Logger LOGGER = Logger.getLogger(LibertyHoverParticipant.class.getName());
+    private static final String MARKDOWN_NEW_LINE = "  \n  \n";
 
     @Override
     public Hover onAttributeName(IHoverRequest request, CancelChecker cancelChecker) {
@@ -61,7 +62,7 @@ public class LibertyHoverParticipant implements IHoverParticipant {
                 stringBuilder.append(String.format("%s = %s", variable.getValue(), variableMap.get(variable.getValue())));
             }
             if (varIter.hasNext()) {
-                stringBuilder.append("\n\n");
+                stringBuilder.append(MARKDOWN_NEW_LINE);
             }
         }
         if (!stringBuilder.isEmpty()) {
@@ -152,7 +153,7 @@ public class LibertyHoverParticipant implements IHoverParticipant {
         String description = flNode.getDescription();
         sb.append(ResourceBundleUtil.getMessage(ResourceBundleMappingConstants.TITLE_HOVER_DESCRIPTION) + " ");
         sb.append(description);
-        sb.append("\n\n");
+        sb.append(MARKDOWN_NEW_LINE);
 
         // get features that directly enable this feature
         Set<String> featureEnabledBy = flNode.getEnabledBy();
@@ -167,7 +168,7 @@ public class LibertyHoverParticipant implements IHoverParticipant {
                 sb.append(", ");
             }
             sb.setLength(sb.length() - 2);
-            sb.append("\n\n");
+            sb.append(MARKDOWN_NEW_LINE);
         }
 
         // get features that this feature directly enables

--- a/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/LibertyHoverParticipant.java
+++ b/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/LibertyHoverParticipant.java
@@ -18,6 +18,7 @@ import org.eclipse.lemminx.services.extensions.hover.IHoverParticipant;
 import org.eclipse.lemminx.services.extensions.hover.IHoverRequest;
 import org.eclipse.lsp4j.Hover;
 import org.eclipse.lsp4j.MarkupContent;
+import org.eclipse.lsp4j.MarkupKind;
 import org.eclipse.lsp4j.jsonrpc.CancelChecker;
 
 import io.openliberty.tools.langserver.lemminx.data.FeatureListGraph;
@@ -60,11 +61,11 @@ public class LibertyHoverParticipant implements IHoverParticipant {
                 stringBuilder.append(String.format("%s = %s", variable.getValue(), variableMap.get(variable.getValue())));
             }
             if (varIter.hasNext()) {
-                stringBuilder.append("<br />");
+                stringBuilder.append("\n\n");
             }
         }
         if (!stringBuilder.isEmpty()) {
-            return new Hover(new MarkupContent("plaintext", stringBuilder.toString()));
+            return new Hover(new MarkupContent(MarkupKind.MARKDOWN, stringBuilder.toString()));
         }
         return null;
     }
@@ -113,7 +114,7 @@ public class LibertyHoverParticipant implements IHoverParticipant {
         if (FeatureService.getInstance().platformExists(platformName, libertyVersion, libertyRuntime, requestDelay, domDocument.getDocumentURI())) {
             String description = LibertyUtils.getPlatformDescription(platformName);
             if (description != null) {
-                return new Hover(new MarkupContent("plaintext", description));
+                return new Hover(new MarkupContent(MarkupKind.MARKDOWN, description));
             }
         } else {
             LOGGER.warning("Could not get description for platform: "+platformName+"  from features.json file. Platform does not exist."); 
@@ -130,7 +131,7 @@ public class LibertyHoverParticipant implements IHoverParticipant {
         final int requestDelay = SettingsService.getInstance().getRequestDelay();
         Optional<Feature> feature = FeatureService.getInstance().getFeature(featureName, libertyVersion, libertyRuntime, requestDelay, domDocument.getDocumentURI());
         if (feature.isPresent()) {
-            return new Hover(new MarkupContent("plaintext", feature.get().getShortDescription()));
+            return new Hover(new MarkupContent(MarkupKind.MARKDOWN, feature.get().getShortDescription()));
         }
 
         return null;
@@ -151,7 +152,7 @@ public class LibertyHoverParticipant implements IHoverParticipant {
         String description = flNode.getDescription();
         sb.append(ResourceBundleUtil.getMessage(ResourceBundleMappingConstants.TITLE_HOVER_DESCRIPTION) + " ");
         sb.append(description);
-        sb.append(System.lineSeparator());
+        sb.append("\n\n");
 
         // get features that directly enable this feature
         Set<String> featureEnabledBy = flNode.getEnabledBy();
@@ -166,7 +167,7 @@ public class LibertyHoverParticipant implements IHoverParticipant {
                 sb.append(", ");
             }
             sb.setLength(sb.length() - 2);
-            sb.append(System.lineSeparator());
+            sb.append("\n\n");
         }
 
         // get features that this feature directly enables
@@ -184,6 +185,6 @@ public class LibertyHoverParticipant implements IHoverParticipant {
             sb.setLength(sb.length() - 2);
         }
 
-       return new Hover(new MarkupContent("plaintext", sb.toString()));
+       return new Hover(new MarkupContent(MarkupKind.MARKDOWN, sb.toString()));
     }
 }

--- a/lemminx-liberty/src/test/java/io/openliberty/LibertyHoverTest.java
+++ b/lemminx-liberty/src/test/java/io/openliberty/LibertyHoverTest.java
@@ -75,9 +75,9 @@ public class LibertyHoverTest {
                             "Description: This feature enables support for Java API for RESTful Web Services v2.1.  "
                                             + "JAX-RS annotations can be used to define web service clients and endpoints that comply with the REST architectural style. "
                                             + "Endpoints are accessed through a common interface that is based on the HTTP standard methods."
-                                            + System.lineSeparator()
+                                            + "\n\n"
                                             + "Enabled by: microProfile-2.0, microProfile-2.1, microProfile-2.2, microProfile-3.0, microProfile-3.2, microProfile-3.3, microProfile-4.0, microProfile-4.1, mpOpenAPI-2.0, opentracing-1.3, opentracing-2.0, webProfile-8.0"
-                                            + System.lineSeparator()
+                                            + "\n\n"
                                             + "Enables: jaxrsClient-2.1, servlet-4.0",
                             r(2, 24, 2, 33));
 
@@ -98,9 +98,9 @@ public class LibertyHoverTest {
                                 "Description: This feature enables support for Java API for RESTful Web Services v2.1.  "
                                                 + "JAX-RS annotations can be used to define web service clients and endpoints that comply with the REST architectural style. "
                                                 + "Endpoints are accessed through a common interface that is based on the HTTP standard methods."
-                                                + System.lineSeparator()
+                                                + "\n\n"
                                                 + "Enabled by: microProfile-2.0, microProfile-2.1, microProfile-2.2, microProfile-3.0, microProfile-3.2, microProfile-3.3, microProfile-4.0, microProfile-4.1, mpOpenAPI-2.0, opentracing-1.3, opentracing-2.0, webProfile-8.0"
-                                                + System.lineSeparator()
+                                                + "\n\n"
                                                 + "Enables: jaxrsClient-2.1, servlet-4.0",
                                 r(2, 24, 2, 34));
 

--- a/lemminx-liberty/src/test/java/io/openliberty/LibertyHoverTest.java
+++ b/lemminx-liberty/src/test/java/io/openliberty/LibertyHoverTest.java
@@ -75,9 +75,9 @@ public class LibertyHoverTest {
                             "Description: This feature enables support for Java API for RESTful Web Services v2.1.  "
                                             + "JAX-RS annotations can be used to define web service clients and endpoints that comply with the REST architectural style. "
                                             + "Endpoints are accessed through a common interface that is based on the HTTP standard methods."
-                                            + "\n\n"
+                                            + "  \n  \n"
                                             + "Enabled by: microProfile-2.0, microProfile-2.1, microProfile-2.2, microProfile-3.0, microProfile-3.2, microProfile-3.3, microProfile-4.0, microProfile-4.1, mpOpenAPI-2.0, opentracing-1.3, opentracing-2.0, webProfile-8.0"
-                                            + "\n\n"
+                                            + "  \n  \n"
                                             + "Enables: jaxrsClient-2.1, servlet-4.0",
                             r(2, 24, 2, 33));
 
@@ -98,9 +98,9 @@ public class LibertyHoverTest {
                                 "Description: This feature enables support for Java API for RESTful Web Services v2.1.  "
                                                 + "JAX-RS annotations can be used to define web service clients and endpoints that comply with the REST architectural style. "
                                                 + "Endpoints are accessed through a common interface that is based on the HTTP standard methods."
-                                                + "\n\n"
+                                                + "  \n  \n"
                                                 + "Enabled by: microProfile-2.0, microProfile-2.1, microProfile-2.2, microProfile-3.0, microProfile-3.2, microProfile-3.3, microProfile-4.0, microProfile-4.1, mpOpenAPI-2.0, opentracing-1.3, opentracing-2.0, webProfile-8.0"
-                                                + "\n\n"
+                                                + "  \n  \n"
                                                 + "Enables: jaxrsClient-2.1, servlet-4.0",
                                 r(2, 24, 2, 34));
 


### PR DESCRIPTION
Fixes #365 

The issue was resolved with three key changes:

1. **Changed MarkupKind from `"plaintext"` to `"markdown"`**:
   - Changed all hover content to use proper `"markdown"` format instead of `"plaintext"`
   - This follows LSP specification for formatted content
   - [LSP Specification - MarkupKind](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#markupContentKind)

2. **Replaced `System.lineSeparator()` with `"\n\n"`**:
   - In markdown, a single newline isn't rendered as a visual break
   - Two consecutive newlines create a paragraph break that's visually displayed
   - Using the `"\n\n"` will ensure consistent rendering across platforms
   - Avoids platform-specific line endings that could affect markdown parsing

### Result
#### 1. IntelliJ
<img width="479" alt="image" src="https://github.com/user-attachments/assets/b5785ebe-9795-4d6b-971a-ab314abe2913" />

#### 2. VS Code
<img width="873" alt="image" src="https://github.com/user-attachments/assets/4675c8e2-8f5a-47b4-8725-778962d330c6" />

#### 3. Eclipse
<img width="898" alt="image" src="https://github.com/user-attachments/assets/1df6d416-3103-49da-a818-2ba7439a75d1" />
