### PR TITLE
Change error to warning for missing value

### DIFF
--- a/liberty-ls/src/main/java/io/openliberty/tools/langserver/utils/PropertiesValidationResult.java
+++ b/liberty-ls/src/main/java/io/openliberty/tools/langserver/utils/PropertiesValidationResult.java
@@ -90,8 +90,8 @@ public class PropertiesValidationResult {
         
 
         if (ServerPropertyValues.usesPredefinedValues(textDocumentItem, property)) {
-            // only issue a warning if a value is not specified
             if (value == null || value.isEmpty()) {
+                // if a value is not specified, issue a warning not an error
                 hasWarnings = true;
                 diagnosticType = LibertyConfigFileManager.isBootstrapPropertiesFile(textDocumentItem) ? 
                                             "EMPTY_PROPERTY_VALUE" : "EMPTY_VARIABLE_VALUE";

--- a/liberty-ls/src/main/resources/DiagnosticMessages.properties
+++ b/liberty-ls/src/main/resources/DiagnosticMessages.properties
@@ -1,3 +1,5 @@
+EMPTY_PROPERTY_VALUE=The value is empty for the property `{1}`. Check whether a value should be specified or whether the property should be removed.
+EMPTY_VARIABLE_VALUE=The value is empty for the variable `{1}`. Check whether a value should be specified or whether the variable should be removed.
 INVALID_PROPERTY_VALUE=The value `{0}` is not valid for the property `{1}`.
 INVALID_VARIABLE_VALUE=The value `{0}` is not valid for the variable `{1}`.
 INVALID_PROPERTY_INTEGER_RANGE=The value `{0}` is not within the valid range `{2}` for the property `{1}`.

--- a/liberty-ls/src/test/java/io/openliberty/tools/langserver/diagnostic/AbstractDiagnosticTest.java
+++ b/liberty-ls/src/test/java/io/openliberty/tools/langserver/diagnostic/AbstractDiagnosticTest.java
@@ -72,18 +72,33 @@ public class AbstractDiagnosticTest extends AbstractLibertyLanguageServerTest {
         assertEquals("Did not find all the expected diagnostics. These expected ranges were not found: " + expectedDiagnosticRanges.toString(), 0, expectedDiagnosticRanges.size());
     }
 
-    protected void checkDiagnosticsContainsMessages(String... messages) {
+    protected void checkDiagnosticsContainsErrorMessages(String... messages) {
         List<Diagnostic> diags = lastPublishedDiagnostics.getDiagnostics();
         List<String> expectedMessages = new LinkedList<String>(Arrays.asList(messages));
 
         for (Diagnostic diag : diags) {
-            assertFalse("Diagnostic message is unexpectedly empty.", diag.getMessage().isEmpty());
-            assertTrue("Diagnostic severity not set to Error as expected.", diag.getSeverity() == DiagnosticSeverity.Error);
-            expectedMessages.remove(diag.getMessage());
+            if (diag.getSeverity() == DiagnosticSeverity.Error) {
+                assertFalse("Diagnostic message is unexpectedly empty.", diag.getMessage().isEmpty());
+                assertTrue("Diagnostic severity not set to Error as expected.", diag.getSeverity() == DiagnosticSeverity.Error);
+                expectedMessages.remove(diag.getMessage());
+            }
         }
-        assertEquals("Did not find all the expected diagnostic messages. These messages were not found: " + expectedMessages.toString(), 0, expectedMessages.size());
+        assertEquals("Did not find all the expected diagnostic error messages. These messages were not found: " + expectedMessages.toString(), 0, expectedMessages.size());
     }
 
+    protected void checkDiagnosticsContainsWarningMessages(String... messages) {
+        List<Diagnostic> diags = lastPublishedDiagnostics.getDiagnostics();
+        List<String> expectedMessages = new LinkedList<String>(Arrays.asList(messages));
+
+        for (Diagnostic diag : diags) {
+            if (diag.getSeverity() == DiagnosticSeverity.Warning) {
+                assertFalse("Diagnostic message is unexpectedly empty.", diag.getMessage().isEmpty());
+                assertTrue("Diagnostic severity not set to Warning as expected.", diag.getSeverity() == DiagnosticSeverity.Warning);
+                expectedMessages.remove(diag.getMessage());
+            }
+        }
+        assertEquals("Did not find all the expected diagnostic warning messages. These messages were not found: " + expectedMessages.toString(), 0, expectedMessages.size());
+    }
     private ConditionFactory createAwait() {
         return await().pollDelay(Duration.ZERO).pollInterval(AWAIT_POLL_INTERVAL).timeout(AWAIT_TIMEOUT);
     }

--- a/liberty-ls/src/test/java/io/openliberty/tools/langserver/diagnostic/AbstractDiagnosticTest.java
+++ b/liberty-ls/src/test/java/io/openliberty/tools/langserver/diagnostic/AbstractDiagnosticTest.java
@@ -79,7 +79,6 @@ public class AbstractDiagnosticTest extends AbstractLibertyLanguageServerTest {
         for (Diagnostic diag : diags) {
             if (diag.getSeverity() == DiagnosticSeverity.Error) {
                 assertFalse("Diagnostic message is unexpectedly empty.", diag.getMessage().isEmpty());
-                assertTrue("Diagnostic severity not set to Error as expected.", diag.getSeverity() == DiagnosticSeverity.Error);
                 expectedMessages.remove(diag.getMessage());
             }
         }
@@ -93,7 +92,6 @@ public class AbstractDiagnosticTest extends AbstractLibertyLanguageServerTest {
         for (Diagnostic diag : diags) {
             if (diag.getSeverity() == DiagnosticSeverity.Warning) {
                 assertFalse("Diagnostic message is unexpectedly empty.", diag.getMessage().isEmpty());
-                assertTrue("Diagnostic severity not set to Warning as expected.", diag.getSeverity() == DiagnosticSeverity.Warning);
                 expectedMessages.remove(diag.getMessage());
             }
         }

--- a/liberty-ls/src/test/java/io/openliberty/tools/langserver/diagnostic/BootstrapPropertyDiagnosticTest.java
+++ b/liberty-ls/src/test/java/io/openliberty/tools/langserver/diagnostic/BootstrapPropertyDiagnosticTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2022 IBM Corporation and others.
+* Copyright (c) 2022, 2025 IBM Corporation and others.
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License v. 2.0 which is available at
@@ -35,9 +35,8 @@ public class BootstrapPropertyDiagnosticTest extends AbstractDiagnosticTest {
             // Checking invalid value: com.ibm.ws.logging.console.source=trace,aud
             createRange(11, 34, 43)
         );
-        checkDiagnosticsContainsMessages(
+        checkDiagnosticsContainsErrorMessages(
             "The value `DEVd` is not valid for the property `com.ibm.ws.logging.console.format`.",
-            "The value `` is not valid for the property `com.ibm.ws.logging.console.source`.",
             "The value `binaryLogging-1.1` is not valid for the property `websphere.log.provider`.",
             "The value `0` is not within the valid range `[1..65535]` for the property `default.http.port`.",
             "The value `2147483648` is not within the valid range `[0..2147483647]` for the property `com.ibm.hpel.log.purgeMaxSize`.",
@@ -45,6 +44,10 @@ public class BootstrapPropertyDiagnosticTest extends AbstractDiagnosticTest {
             "This value must be a comma-delimited list of Java packages.",
             "The value `DEVd` is not valid for the property `com.ibm.ws.logging.console.format`.",
             "The value `aud` is not valid for the property `com.ibm.ws.logging.console.source`."
+        );
+
+        checkDiagnosticsContainsWarningMessages(
+            "The value is empty for the property `com.ibm.ws.logging.console.source`. Check whether a value should be specified or whether the property should be removed."
         );
     }
 }

--- a/liberty-ls/src/test/java/io/openliberty/tools/langserver/diagnostic/ServerEnvDiagnosticTest.java
+++ b/liberty-ls/src/test/java/io/openliberty/tools/langserver/diagnostic/ServerEnvDiagnosticTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2022, 2023 IBM Corporation and others.
+* Copyright (c) 2022, 2025 IBM Corporation and others.
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License v. 2.0 which is available at
@@ -16,7 +16,7 @@ public class ServerEnvDiagnosticTest extends AbstractDiagnosticTest {
     @Test
     public void testServerEnv() throws Exception {
         // has invalid, case-sensitive, case-insensitive, and negative port integer values.
-        testDiagnostic("server.env", 7);
+        testDiagnostic("server.env", 8);
         checkDiagnosticsContainsAllRanges(
             // Checking invalid value: WLP_LOGGING_CONSOLE_FORMAT=asdf
             createRange(0, 27, 31),
@@ -31,9 +31,11 @@ public class ServerEnvDiagnosticTest extends AbstractDiagnosticTest {
             // Checking invalid case-sensitive property: WLP_LOGGING_CONSOLE_SOURCE=messagE
             createRange(9, 27, 34),
             // Checking invalid case-sensitive property: WLP_LOGGING_MESSAGE_SOURCE=message,au
-            createRange(10, 27, 37)
+            createRange(10, 27, 37),
+            // Checking invalid empty property: WLP_DEBUG_SUSPEND=
+            createRange(11, 18, 18)
         );
-        checkDiagnosticsContainsMessages(
+        checkDiagnosticsContainsErrorMessages(
             "The value `asdf` is not valid for the variable `WLP_LOGGING_CONSOLE_FORMAT`.",
             "The value `messagE` is not valid for the variable `WLP_LOGGING_CONSOLE_SOURCE`.",
             "The value `-2` is not within the valid range `[1..65535]` for the variable `WLP_DEBUG_ADDRESS`.",
@@ -41,6 +43,10 @@ public class ServerEnvDiagnosticTest extends AbstractDiagnosticTest {
             "There should be no whitespace surrounding the equal sign (=).",
             "The value `messagE` is not valid for the variable `WLP_LOGGING_CONSOLE_SOURCE`.",
             "The value `au` is not valid for the variable `WLP_LOGGING_MESSAGE_SOURCE`."
+        );
+
+        checkDiagnosticsContainsWarningMessages(
+            "The value is empty for the variable `WLP_DEBUG_SUSPEND`. Check whether a value should be specified or whether the variable should be removed."
         );
     }
 }

--- a/liberty-ls/src/test/java/io/openliberty/tools/langserver/diagnostic/ServerEnvDiagnosticTest.java
+++ b/liberty-ls/src/test/java/io/openliberty/tools/langserver/diagnostic/ServerEnvDiagnosticTest.java
@@ -32,7 +32,7 @@ public class ServerEnvDiagnosticTest extends AbstractDiagnosticTest {
             createRange(9, 27, 34),
             // Checking invalid case-sensitive property: WLP_LOGGING_MESSAGE_SOURCE=message,au
             createRange(10, 27, 37),
-            // Checking invalid empty property: WLP_DEBUG_SUSPEND=
+            // Checking empty variable: WLP_DEBUG_SUSPEND=
             createRange(11, 18, 18)
         );
         checkDiagnosticsContainsErrorMessages(

--- a/liberty-ls/src/test/resources/workspace/diagnostic/src/main/liberty/config/server.env
+++ b/liberty-ls/src/test/resources/workspace/diagnostic/src/main/liberty/config/server.env
@@ -9,3 +9,4 @@ WLP_LOGGING_MESSAGE_FORMAT= SIMPLE
 #adding same line again to check diagnostic is coming on both lines
 WLP_LOGGING_CONSOLE_SOURCE=messagE
 WLP_LOGGING_MESSAGE_SOURCE=message,au
+WLP_DEBUG_SUSPEND=


### PR DESCRIPTION
Fixes #370 

For any variable/property with a set of predefined values, change the error diagnostic to a warning diagnostic. The quick fix will remain for setting the value to one of the valid predefined values.