### PR TITLE
introduced locale fallback methods

### DIFF
--- a/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/util/ResourceBundleUtil.java
+++ b/lemminx-liberty/src/main/java/io/openliberty/tools/langserver/lemminx/util/ResourceBundleUtil.java
@@ -92,8 +92,8 @@ public final class ResourceBundleUtil {
             return new Locale(parts[0], parts[1], parts[2]);
         }
         // If all else fails, return a default locale
-        LOGGER.warning("Setting locale as en_US as initializeParams locale is null");
-        return Locale.US;
+        LOGGER.warning("Setting locale as en as initializeParams locale is null");
+        return Locale.ENGLISH;
     }
 
     /**

--- a/lemminx-liberty/src/test/java/io/openliberty/LibertyFeatureTest.java
+++ b/lemminx-liberty/src/test/java/io/openliberty/LibertyFeatureTest.java
@@ -10,6 +10,7 @@ import java.util.Collection;
 import java.util.List;
 
 import io.openliberty.tools.langserver.lemminx.services.SettingsService;
+import org.eclipse.lsp4j.InitializeParams;
 import org.eclipse.lsp4j.WorkspaceFolder;
 import org.junit.jupiter.api.Test;
 
@@ -25,7 +26,9 @@ public class LibertyFeatureTest {
     
     @Test
     public void getInstalledFeaturesListTest() throws JAXBException {
-        SettingsService.getInstance().initializeLocale(null);
+        InitializeParams initParams = new InitializeParams();
+        initParams.setLocale("en-us");
+        SettingsService.getInstance().initializeLocale(initParams);
         FeatureService fs = FeatureService.getInstance();
         File srcResourcesDir = new File("src/test/resources/sample");
         File featureListFile = new File(srcResourcesDir.getParentFile(), "featurelist-ol-25.0.0.6.xml");
@@ -57,5 +60,6 @@ public class LibertyFeatureTest {
         assertEquals(292, fg.getAllEnabledBy("library").size());
         assertTrue(fg.getAllEnabledBy("ltpa").contains("admincenter-1.0"));  // direct enabler
         assertTrue(fg.getAllEnabledBy("ssl").contains("microprofile-5.0"));  // transitive enabler
+        assertEquals("en",SettingsService.getInstance().getCurrentLocale().toString());
     }
 }

--- a/lemminx-liberty/src/test/java/io/openliberty/SettingsServiceTest.java
+++ b/lemminx-liberty/src/test/java/io/openliberty/SettingsServiceTest.java
@@ -145,6 +145,30 @@ public class SettingsServiceTest {
         SettingsService.getInstance().initializeLocale(initParams);
         assertEquals("es_ES",SettingsService.getInstance().getCurrentLocale().toString());
 
+        // testing with language code and country, liberty supports "zh_TW" locale
+        initParams.setLocale("zh_TW");
+        SettingsService.getInstance().initializeLocale(initParams);
+        assertEquals("zh_TW",SettingsService.getInstance().getCurrentLocale().toString());
+        initParams.setLocale("zh-tw");
+        SettingsService.getInstance().initializeLocale(initParams);
+        assertEquals("zh_TW",SettingsService.getInstance().getCurrentLocale().toString());
+        initParams.setLocale("zh_tw");
+        SettingsService.getInstance().initializeLocale(initParams);
+        assertEquals("zh_TW",SettingsService.getInstance().getCurrentLocale().toString());
+
+
+        // testing with language code and country, liberty supports "zh_CN" locale
+        initParams.setLocale("zh_CN");
+        SettingsService.getInstance().initializeLocale(initParams);
+        assertEquals("zh_CN",SettingsService.getInstance().getCurrentLocale().toString());
+        initParams.setLocale("zh-cn");
+        SettingsService.getInstance().initializeLocale(initParams);
+        assertEquals("zh_CN",SettingsService.getInstance().getCurrentLocale().toString());
+        initParams.setLocale("ZH-CN");
+        SettingsService.getInstance().initializeLocale(initParams);
+        assertEquals("zh_CN",SettingsService.getInstance().getCurrentLocale().toString());
+
+
         // Language, Script, and Region format
         initParams.setLocale("en-Latn-US");
         SettingsService.getInstance().initializeLocale(initParams);

--- a/lemminx-liberty/src/test/java/io/openliberty/SettingsServiceTest.java
+++ b/lemminx-liberty/src/test/java/io/openliberty/SettingsServiceTest.java
@@ -4,6 +4,8 @@ import io.openliberty.tools.langserver.lemminx.services.LibertyProjectsManager;
 import io.openliberty.tools.langserver.lemminx.services.LibertyWorkspace;
 import io.openliberty.tools.langserver.lemminx.services.SettingsService;
 import io.openliberty.tools.langserver.lemminx.util.LibertyUtils;
+import io.openliberty.tools.langserver.lemminx.util.ResourceBundleUtil;
+import org.eclipse.lsp4j.InitializeParams;
 import org.eclipse.lsp4j.WorkspaceFolder;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -16,6 +18,7 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Properties;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -91,4 +94,76 @@ public class SettingsServiceTest {
         assertEquals("includes", variables.get("includeLocation"));
     }
 
+    @Test
+    public void testInitializeLocale(){
+        InitializeParams initParams = new InitializeParams();
+        //language only
+        initParams.setLocale("en");
+        SettingsService.getInstance().initializeLocale(initParams);
+        assertEquals("en",SettingsService.getInstance().getCurrentLocale().toString());
+
+        initParams.setLocale("FR");
+        SettingsService.getInstance().initializeLocale(initParams);
+        assertEquals("fr",SettingsService.getInstance().getCurrentLocale().toString());
+
+        initParams.setLocale("ja");
+        SettingsService.getInstance().initializeLocale(initParams);
+        assertEquals("ja",SettingsService.getInstance().getCurrentLocale().toString());
+
+        // language and region, should return matching locale en as liberty only uses "en"
+        // testing with different formats
+        initParams.setLocale("en-us");
+        SettingsService.getInstance().initializeLocale(initParams);
+        assertEquals("en",SettingsService.getInstance().getCurrentLocale().toString());
+        initParams.setLocale("en-Us");
+        SettingsService.getInstance().initializeLocale(initParams);
+        assertEquals("en",SettingsService.getInstance().getCurrentLocale().toString());
+        initParams.setLocale("en-US");
+        SettingsService.getInstance().initializeLocale(initParams);
+        assertEquals("en",SettingsService.getInstance().getCurrentLocale().toString());
+        initParams.setLocale("EN-US");
+        SettingsService.getInstance().initializeLocale(initParams);
+        assertEquals("en",SettingsService.getInstance().getCurrentLocale().toString());
+        initParams.setLocale("en");
+        SettingsService.getInstance().initializeLocale(initParams);
+        assertEquals("en",SettingsService.getInstance().getCurrentLocale().toString());
+        initParams.setLocale("EN_US");
+        SettingsService.getInstance().initializeLocale(initParams);
+        assertEquals("en",SettingsService.getInstance().getCurrentLocale().toString());
+        initParams.setLocale("en_us");
+        SettingsService.getInstance().initializeLocale(initParams);
+        assertEquals("en",SettingsService.getInstance().getCurrentLocale().toString());
+        initParams.setLocale("de_AT");
+        SettingsService.getInstance().initializeLocale(initParams);
+        assertEquals("de",SettingsService.getInstance().getCurrentLocale().toString());
+
+        // testing with language code and country, liberty supports "es_ES" locale
+        initParams.setLocale("es-Es");
+        SettingsService.getInstance().initializeLocale(initParams);
+        assertEquals("es_ES",SettingsService.getInstance().getCurrentLocale().toString());
+        initParams.setLocale("es_Es");
+        SettingsService.getInstance().initializeLocale(initParams);
+        assertEquals("es_ES",SettingsService.getInstance().getCurrentLocale().toString());
+
+        // Language, Script, and Region format
+        initParams.setLocale("en-Latn-US");
+        SettingsService.getInstance().initializeLocale(initParams);
+        assertEquals("en",SettingsService.getInstance().getCurrentLocale().toString());
+
+        // default to en for valid, but not matching with liberty locales
+        initParams.setLocale("hi_IN");
+        SettingsService.getInstance().initializeLocale(initParams);
+        assertEquals("en",SettingsService.getInstance().getCurrentLocale().toString());
+
+        // default to en for invalid
+        initParams.setLocale("en-krp");
+        SettingsService.getInstance().initializeLocale(initParams);
+        assertEquals("en",SettingsService.getInstance().getCurrentLocale().toString());
+        // all liberty supported locales are working as-is
+        for (Locale locale : ResourceBundleUtil.getAvailableLocales()) {
+            initParams.setLocale(locale.toString());
+            SettingsService.getInstance().initializeLocale(initParams);
+            assertEquals(locale.toString(), SettingsService.getInstance().getCurrentLocale().toString());
+        }
+    }
 }


### PR DESCRIPTION
resolving #383 

Added code changes to find locale from any locale formats(en-us,en_US,en)
Also added code to match the current locale with existing liberty allowed locales and default to english if no match is found

Tested in vscode using different locales set using argv.json and directly by configuring language
Language server now accepts valid locales in all standard formats and if it cannot be matched, locale is defaulted to english

Test Video size is huge, uploading to [onedrive](https://ibm-my.sharepoint.com/:v:/p/arun_kumar_v_n/EcJuhdyCpptEkXRHQrZB_CkBXe8coDLCkJUpaMEk6U1O_w?nav=eyJyZWZlcnJhbEluZm8iOnsicmVmZXJyYWxBcHAiOiJPbmVEcml2ZUZvckJ1c2luZXNzIiwicmVmZXJyYWxBcHBQbGF0Zm9ybSI6IldlYiIsInJlZmVycmFsTW9kZSI6InZpZXciLCJyZWZlcnJhbFZpZXciOiJNeUZpbGVzTGlua0NvcHkifX0&e=w9g7WI)


